### PR TITLE
husky/pre-commit: replace pushd/popd with subshell for /bin/sh portab…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,16 +18,17 @@ echo '➡️ run tests check'
 npm run test || { echo '❌ tests check failed.'; exit 1; }
 
 echo '🔍 Running forge-sql-orm-cli resources checks...'
-pushd forge-sql-orm-cli > /dev/null
+# Subshell instead of pushd/popd — pushd is a bash builtin and /bin/sh on
+# CI runners (Ubuntu /bin/sh -> dash) doesn't have it.
+(
+  cd forge-sql-orm-cli || exit 1
 
-echo '➡️ lint-staged (forge-sql-orm-cli resources)'
-npx lint-staged || { echo '❌ lint-staged failed for forge-sql-orm-cli resources'; popd > /dev/null; exit 1; }
+  echo '➡️ lint-staged (forge-sql-orm-cli resources)'
+  npx lint-staged || { echo '❌ lint-staged failed for forge-sql-orm-cli resources'; exit 1; }
 
+  echo '➡️ dependencies check'
+  npm run knip || { echo '❌ Dependency check for forge-sql-orm-cli resources failed.'; exit 1; }
 
-echo '➡️ dependencies check'
-npm run knip || { echo '❌ Dependency check for forge-sql-orm-cli resources failed.'; exit 1; }
-
-echo '➡️ build'
-npm run build || { echo '❌ Build failed'; popd > /dev/null; exit 1; }
-
-popd > /dev/null
+  echo '➡️ build'
+  npm run build || { echo '❌ Build failed'; exit 1; }
+)


### PR DESCRIPTION
…ility

On Ubuntu CI runners /bin/sh is dash, which has no pushd/popd builtin, so the hook failed with ".husky/pre-commit: 21: pushd: not found" the moment the autoupdate workflow tried to git commit. Locally on macOS /bin/sh is bash, masking the issue.

Wrap the forge-sql-orm-cli block in a subshell and cd inside it. The parent shell's cwd is untouched, no pushd/popd needed, runs on every POSIX shell.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)
