### PR TITLE
autoupdate.yml: clean orphan dependencies/auto-* branches + force-push

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -55,17 +55,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Gather open PRs carrying the label
+          # 1) Close PRs carrying the label (auto-deletes the head branch).
           prs=$(gh pr list --label dependencies_updated --state open --json number --jq '.[].number')
-          if [ -z "$prs" ]; then
+          if [ -n "$prs" ]; then
+            for pr in $prs; do
+              echo "Closing PR #$pr"
+              gh pr close "$pr" \
+                --delete-branch \
+                --comment "Superseded by today's autoupdate run."
+            done
+          else
             echo "No existing autoupdate PRs to close."
-            exit 0
           fi
-          for pr in $prs; do
-            echo "Closing PR #$pr"
-            gh pr close "$pr" \
-              --delete-branch \
-              --comment "Superseded by today's autoupdate run."
+
+          # 2) Sweep up orphan dependencies/auto-* branches (pushed but never
+          #    PR'd — e.g. when a previous run failed before gh pr create).
+          orphans=$(gh api -X GET repos/${{ github.repository }}/branches \
+            --paginate --jq '.[].name' | grep '^dependencies/auto-' || true)
+          for b in $orphans; do
+            echo "Deleting orphan branch $b"
+            git push origin --delete "$b" || true
           done
 
       - name: Run autoupdate.sh
@@ -96,7 +105,10 @@ jobs:
           # Stage anything autoupdate.sh did not stage explicitly
           git add -A
           git commit -m "chore(deps): daily autoupdate ${DATE}"
-          git push -u origin "$BRANCH"
+          # Force-push as a safety net: the orphan-branch sweep above usually
+          # clears any pre-existing remote ref, but a same-day re-run would
+          # otherwise hit non-fast-forward on the second push.
+          git push -u origin "$BRANCH" --force
 
           gh pr create \
             --base master \


### PR DESCRIPTION
The previous run pushed dependencies/auto-2026-05-12 to origin but gh pr create failed (permission policy), leaving the branch on the remote with no associated PR. The next run hit non-fast-forward because the workflow only deletes branches via gh pr close, which only handles branches that actually had a PR.

Two fixes:

- After closing labeled PRs, sweep every remote branch matching dependencies/auto-* and delete it. Catches orphans from any prior partial failure.
- Force-push the freshly created branch as a safety net for same-day re-runs (where the orphan-sweep finds the branch we just deleted is gone but a subsequent run still wants the same name).

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)
