### PR TITLE
autoupdate.yml: switch to AUTOUPDATE_PAT so opened PRs trigger CI

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOUPDATE_PAT }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -44,7 +44,7 @@ jobs:
 
       - name: Ensure label exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOUPDATE_PAT }}
         run: |
           gh label create dependencies_updated \
             --color "0E8A16" \
@@ -53,7 +53,7 @@ jobs:
 
       - name: Close existing autoupdate PRs and delete their branches
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOUPDATE_PAT }}
         run: |
           # 1) Close PRs carrying the label (auto-deletes the head branch).
           prs=$(gh pr list --label dependencies_updated --state open --json number --jq '.[].number')
@@ -96,7 +96,7 @@ jobs:
       - name: Create branch, commit, push, open PR
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOUPDATE_PAT }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
           BRANCH="dependencies/auto-${DATE}"


### PR DESCRIPTION
secrets.GITHUB_TOKEN cannot trigger workflow_run / pull_request events on other workflows — that's why required checks (build, qlty, SonarCloud) sat in "Expected — waiting for status to be reported" on PRs the autoupdate job opened.

Swap all four references (checkout token + the three gh calls) to use secrets.AUTOUPDATE_PAT, a fine-grained PAT owned by Vasyl with contents/pull-requests/issues write. PR events that result from PAT- driven gh pr create DO trigger downstream workflows, so node.js.yml will run on autoupdate PRs and the merge gate works again. Bonus: the PR shows up as opened by Vasyl rather than github-actions[bot].

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)
