### PR TITLE
autoupdate.yml: bail cleanly when the husky hook collapses the diff

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -104,6 +104,16 @@ jobs:
           git checkout -b "$BRANCH"
           # Stage anything autoupdate.sh did not stage explicitly
           git add -A
+
+          # Final guard: the husky pre-commit hook re-runs npm i during commit,
+          # which can regenerate package-lock.json deterministically and
+          # collapse the diff that Detect changes saw. If nothing remains
+          # staged after the final add -A, exit cleanly — no PR needed.
+          if git diff --cached --quiet; then
+            echo "Nothing staged to commit after final add -A. Exiting cleanly."
+            exit 0
+          fi
+
           git commit -m "chore(deps): daily autoupdate ${DATE}"
           # Force-push as a safety net: the orphan-branch sweep above usually
           # clears any pre-existing remote ref, but a same-day re-run would


### PR DESCRIPTION
When master is already at the latest of everything, autoupdate.sh's ncu -u is a no-op and the only diff is package-lock.json reshuffle from the rm-and-reinstall pass. The Detect changes step sees that diff and sets changed=true, so the commit step runs. But the husky pre-commit hook itself runs another npm i during commit (via the prepare script), which regenerates package-lock.json deterministically and reverts the diff. By the time git commit returns from the hook, nothing is staged, git prints "nothing to commit, working tree clean" and exits 1, failing the whole workflow.

Add a guard right before commit: if git diff --cached --quiet, exit 0 instead of letting git commit fail. This is the genuine "no real update today" path, not an error.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)
