### PR TITLE
forge-sql-orm-cli: drop unrecognized externalImportAttributes rollup …

### DIFF
--- a/forge-sql-orm-cli/vite.config.mjs
+++ b/forge-sql-orm-cli/vite.config.mjs
@@ -23,7 +23,6 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           esModule: true,
-          externalImportAttributes: true,
           exports: "named",
         },
       },


### PR DESCRIPTION
…option

Newer Rollup (bundled with Vite 8.0.12+) emits

    Warning: Invalid output options (1 issue found)
    - For the "externalImportAttributes". Invalid key: Expected never but received "externalImportAttributes".

every time vite build runs. The option was removed from rollupOptions.output; current Rollup preserves import attributes by default, so just dropping the key fixes the warning and keeps behaviour the same.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)
