### PR TITLE
ci(automerge): use AUTOUPDATE_PAT so merge commit triggers CI

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,4 +24,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOUPDATE_PAT }}


### PR DESCRIPTION
Auto-merge enabled with GITHUB_TOKEN runs as github-actions[bot]; pushes authored by it do not trigger downstream workflows, so forge-sql-orm CI never ran on master after dependency PRs merged.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)
