### PR TITLE
ci: add retry logic for Forge deploy and install in CI workflows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -155,14 +155,26 @@ jobs:
         if: matrix.static
         run: cd examples/${{ matrix.dir }}/static/forge-orm-example && npm run build
 
+      # One retry: Forge deploys hit transient Atlassian-side failures.
       - name: Forge Deploy (${{ env.FORGE_ENV }})
         if: github.actor != 'dependabot[bot]'
         env:
           FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
           FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
-        run: cd examples/${{ matrix.dir }} && forge deploy --non-interactive -e $FORGE_ENV
+        run: |
+          cd "examples/${{ matrix.dir }}"
+          for attempt in 1 2; do
+            if forge deploy --non-interactive -e "$FORGE_ENV"; then
+              exit 0
+            fi
+            echo "::warning::forge deploy attempt $attempt failed for ${{ matrix.dir }}"
+            [ "$attempt" -lt 2 ] && sleep $((RANDOM % 21 + 10))
+          done
+          echo "forge deploy failed after 2 attempts"
+          exit 1
       # Existing install on this site+environment -> --upgrade; otherwise a
       # fresh install. The install list is parsed inline with Node.js.
+      # One retry (re-evaluated each attempt) for transient Atlassian failures.
       - name: Forge Install (${{ env.FORGE_ENV }})
         if: github.actor != 'dependabot[bot]'
         env:
@@ -171,28 +183,39 @@ jobs:
           FORGE_HOSTNAME: ${{ secrets.FORGE_HOSTNAME }}
         run: |
           cd "examples/${{ matrix.dir }}"
-          installs="$(forge install list --json 2>/dev/null || echo '[]')"
-          already_installed="$(FORGE_INSTALLS="$installs" node -e '
-            const raw = process.env.FORGE_INSTALLS || "[]";
-            let data;
-            try { data = JSON.parse(raw); } catch { data = []; }
-            const list = Array.isArray(data) ? data : (data.installations || data.result || data.data || []);
-            const host = (process.env.FORGE_HOSTNAME || "").toLowerCase();
-            const envName = (process.env.FORGE_ENV || "").toLowerCase();
-            const found = list.some((i) => {
-              const site = String(i.site || i.siteUrl || i.host || i.hostname || "").toLowerCase();
-              const env = String(i.environmentKey || i.environment || i.environmentType || "").toLowerCase();
-              return site.includes(host) && env === envName;
-            });
-            process.stdout.write(found ? "yes" : "no");
-          ')"
-          if [ "$already_installed" = "yes" ]; then
-            echo "Found existing installation on $FORGE_HOSTNAME ($FORGE_ENV) -> upgrading"
-            forge install -e "$FORGE_ENV" -s "$FORGE_HOSTNAME" -p Jira --confirm-scopes --non-interactive --upgrade
-          else
-            echo "No installation on $FORGE_HOSTNAME ($FORGE_ENV) -> fresh install"
-            forge install -e "$FORGE_ENV" -s "$FORGE_HOSTNAME" -p Jira --confirm-scopes --non-interactive
-          fi
+          install_once() {
+            installs="$(forge install list --json 2>/dev/null || echo '[]')"
+            already_installed="$(FORGE_INSTALLS="$installs" node -e '
+              const raw = process.env.FORGE_INSTALLS || "[]";
+              let data;
+              try { data = JSON.parse(raw); } catch { data = []; }
+              const list = Array.isArray(data) ? data : (data.installations || data.result || data.data || []);
+              const host = (process.env.FORGE_HOSTNAME || "").toLowerCase();
+              const envName = (process.env.FORGE_ENV || "").toLowerCase();
+              const found = list.some((i) => {
+                const site = String(i.site || i.siteUrl || i.host || i.hostname || "").toLowerCase();
+                const env = String(i.environmentKey || i.environment || i.environmentType || "").toLowerCase();
+                return site.includes(host) && env === envName;
+              });
+              process.stdout.write(found ? "yes" : "no");
+            ')"
+            if [ "$already_installed" = "yes" ]; then
+              echo "Found existing installation on $FORGE_HOSTNAME ($FORGE_ENV) -> upgrading"
+              forge install -e "$FORGE_ENV" -s "$FORGE_HOSTNAME" -p Jira --confirm-scopes --non-interactive --upgrade
+            else
+              echo "No installation on $FORGE_HOSTNAME ($FORGE_ENV) -> fresh install"
+              forge install -e "$FORGE_ENV" -s "$FORGE_HOSTNAME" -p Jira --confirm-scopes --non-interactive
+            fi
+          }
+          for attempt in 1 2; do
+            if install_once; then
+              exit 0
+            fi
+            echo "::warning::forge install attempt $attempt failed for ${{ matrix.dir }}"
+            [ "$attempt" -lt 2 ] && sleep $((RANDOM % 21 + 10))
+          done
+          echo "forge install failed after 2 attempts"
+          exit 1
 
   build:
     if: always()

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -183,6 +183,10 @@ jobs:
           FORGE_HOSTNAME: ${{ secrets.FORGE_HOSTNAME }}
         run: |
           cd "examples/${{ matrix.dir }}"
+          if [ -z "${FORGE_HOSTNAME:-}" ]; then
+            echo "::error::FORGE_HOSTNAME secret is empty or unset — refusing to install (an empty host matches every site)"
+            exit 1
+          fi
           install_once() {
             # Don't mask failures: if the list call fails (e.g. transient
             # network error) return non-zero so the loop retries the whole
@@ -198,7 +202,7 @@ jobs:
               const list = Array.isArray(data) ? data : (data.installations || data.result || data.data || []);
               const host = (process.env.FORGE_HOSTNAME || "").toLowerCase();
               const envName = (process.env.FORGE_ENV || "").toLowerCase();
-              const found = list.some((i) => {
+              const found = !!host && list.some((i) => {
                 const site = String(i.site || i.siteUrl || i.host || i.hostname || "").toLowerCase();
                 const env = String(i.environmentKey || i.environment || i.environmentType || "").toLowerCase();
                 return site.includes(host) && env === envName;

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -184,7 +184,13 @@ jobs:
         run: |
           cd "examples/${{ matrix.dir }}"
           install_once() {
-            installs="$(forge install list --json 2>/dev/null || echo '[]')"
+            # Don't mask failures: if the list call fails (e.g. transient
+            # network error) return non-zero so the loop retries the whole
+            # sequence, instead of silently assuming "not installed".
+            if ! installs="$(forge install list --json)"; then
+              echo "::warning::forge install list failed for ${{ matrix.dir }}"
+              return 1
+            fi
             already_installed="$(FORGE_INSTALLS="$installs" node -e '
               const raw = process.env.FORGE_INSTALLS || "[]";
               let data;


### PR DESCRIPTION
- Introduced retry logic (up to 2 attempts) for `forge deploy` and `forge install` steps to handle transient Atlassian-side failures.
- Improved error handling with warnings and randomized backoff between retries.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment and installation reliability by adding automatic retries with randomized backoff (up to two attempts) and warning logs, reducing transient failures.
  * Installation step now validates required environment configuration before proceeding and upgrades existing installations when appropriate, improving consistency of environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->