### PR TITLE
refactor: implement caching abstraction and add Forge KVS cache integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1820,11 +1820,16 @@ This multi-level approach provides optimal performance by checking the fastest c
 
 The caching system uses Atlassian Forge's Custom entity store to persist cache data. Each cache entry is stored as a custom entity with TTL management via Forge KVS. Note that expired data deletion is asynchronous and may take up to 48 hours. If cache growth impacts INSERT/UPDATE performance, use the Clear Cache Scheduler Trigger for proactive cleanup.
 
+The cache backend is pluggable via the `cacheImplementation` option, which accepts any implementation of the [`Cache`](src/lib/cache/Cache.ts) interface. Provide `KVSCache` to enable Forge KVS–backed global caching:
+
 ```typescript
+import { ForgeSQL, KVSCache } from "forge-sql-orm";
+
 const options = {
   cacheEntityName: "cache", // KVS Custom entity name for cache storage
   cacheTTL: 300, // Default cache TTL in seconds (5 minutes)
   cacheWrapTable: true, // Wrap table names with backticks in cache keys
+  cacheImplementation: new KVSCache(), // Forge KVS–backed cache; omit/replace to disable or customize
   additionalMetadata: {
     users: {
       tableName: "users",
@@ -1837,6 +1842,8 @@ const options = {
 
 const forgeSQL = new ForgeSQL(options);
 ```
+
+> **Migration note:** during the transition to the modular architecture the default `cacheImplementation` is `new KVSCache()`, so existing apps keep their current Forge KVS caching behavior without any code changes. To opt out of global caching, pass `cacheImplementation: new NopCache()` (a no-op cache that warns and never stores anything).
 
 ### How Caching Works with @forge/kvs
 
@@ -2473,6 +2480,7 @@ The `ForgeSqlOrmOptions` object allows customization of ORM behavior:
 | `cacheEntityName`          | `string`  | KVS Custom entity name for cache storage. Must match the `name` in your `manifest.yml` storage entities configuration. Required for caching functionality. Defaults to `"cache"`.                                                                                              |
 | `cacheTTL`                 | `number`  | Default cache TTL in seconds. Defaults to `120` (2 minutes).                                                                                                                                                                                                                   |
 | `cacheWrapTable`           | `boolean` | Whether to wrap table names with backticks in cache keys. Defaults to `true`.                                                                                                                                                                                                  |
+| `cacheImplementation`      | `Cache`   | Pluggable cache backend implementing the [`Cache`](src/lib/cache/Cache.ts) interface. Use `new KVSCache()` for Forge KVS–backed global caching, or `new NopCache()` to disable it. Defaults to `new KVSCache()`.                                                               |
 | `hints`                    | `object`  | SQL hints for query optimization. Optional configuration for advanced query tuning.                                                                                                                                                                                            |
 
 ## CLI Commands

--- a/__tests__/src/core/ForgeSQLCacheOperations.test.ts
+++ b/__tests__/src/core/ForgeSQLCacheOperations.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ForgeSQLCacheOperations } from "../../../src/core/ForgeSQLCacheOperations";
-import { ForgeSqlOrmOptions } from "../../../src/core/ForgeSQLQueryBuilder";
+import { ForgeSqlOrmOptions } from "../../../src";
 import {
   clearCache,
   clearTablesCache,

--- a/__tests__/src/lib/cache/KVSCache.test.ts
+++ b/__tests__/src/lib/cache/KVSCache.test.ts
@@ -1,0 +1,450 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DateTime } from "luxon";
+import { ForgeSqlOrmOptions } from "../../../../src/core/ForgeSQLQueryBuilder";
+
+// Hoisted mocks so the @forge/kvs mock factory can reference them safely.
+const { mockKvs, mockContains, mockLessThan, mockFilterOr } = vi.hoisted(() => ({
+  mockKvs: {
+    entity: vi.fn(),
+    transact: vi.fn(),
+    batchDelete: vi.fn(),
+  },
+  mockContains: vi.fn((value: string) => ({ contains: value })),
+  mockLessThan: vi.fn((value: number) => ({ lessThan: value })),
+  mockFilterOr: vi.fn(),
+}));
+
+vi.mock("@forge/kvs", () => {
+  class MockFilter {
+    or(...args: unknown[]) {
+      mockFilterOr(...args);
+      return this;
+    }
+  }
+  return {
+    kvs: mockKvs,
+    Filter: MockFilter,
+    FilterConditions: { contains: mockContains },
+    WhereConditions: { lessThan: mockLessThan },
+  };
+});
+
+const mockIsTableInContext = vi.hoisted(() => vi.fn());
+vi.mock("../../../../src/utils/cacheContextUtils", () => ({
+  isTableContainsTableInCacheContext: mockIsTableInContext,
+  cacheApplicationContext: { getStore: vi.fn() },
+}));
+
+import { KVSCache } from "../../../../src/lib/cache/KVSCache";
+
+// Builds a query-builder mock whose terminal getMany resolves to the given pages.
+const queryBuilder = (
+  pages: Array<{ results: Array<{ key: string }>; nextCursor: string | null }>,
+) => {
+  const getMany = vi.fn();
+  pages.forEach((page) => getMany.mockResolvedValueOnce(page));
+  return {
+    index: vi.fn().mockReturnThis(),
+    filters: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    cursor: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    getMany,
+  };
+};
+
+describe("KVSCache", () => {
+  let cache: KVSCache;
+
+  const defaultOptions: ForgeSqlOrmOptions = {
+    cacheEntityName: "cache",
+    cacheTTL: 120,
+    logCache: true,
+    cacheWrapTable: true,
+  };
+
+  const mockQuery = {
+    toSQL: () => ({ sql: "SELECT * FROM `users` WHERE id = ?", params: [1] }),
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+    cache = new KVSCache();
+    mockKvs.batchDelete.mockResolvedValue({ failedKeys: [] });
+    mockIsTableInContext.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("getQueryResultsFromCache", () => {
+    it("throws when cacheEntityName is not configured", async () => {
+      await expect(
+        cache.getQueryResultsFromCache(mockQuery, {
+          ...defaultOptions,
+          cacheEntityName: undefined,
+        }),
+      ).rejects.toThrow("cacheEntityName is not configured");
+    });
+
+    it("returns undefined and skips KVS when the table is queued for invalidation", async () => {
+      mockIsTableInContext.mockResolvedValue(true);
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, defaultOptions);
+
+      expect(result).toBeUndefined();
+      expect(mockKvs.entity).not.toHaveBeenCalled();
+    });
+
+    it("returns parsed data when the entry is valid and not expired", async () => {
+      mockKvs.entity.mockReturnValue({
+        get: vi.fn().mockResolvedValue({
+          sql: "`users`",
+          expiration: Math.floor(DateTime.now().plus({ hours: 1 }).toSeconds()),
+          data: JSON.stringify({ id: 1, name: "John" }),
+        }),
+      });
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, defaultOptions);
+
+      expect(result).toEqual({ id: 1, name: "John" });
+      expect(mockKvs.entity).toHaveBeenCalledWith("cache");
+    });
+
+    it("returns undefined and logs when the entry is expired", async () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+      mockKvs.entity.mockReturnValue({
+        get: vi.fn().mockResolvedValue({
+          sql: "`users`",
+          expiration: Math.floor(DateTime.now().minus({ hours: 1 }).toSeconds()),
+          data: JSON.stringify({ id: 1 }),
+        }),
+      });
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, defaultOptions);
+
+      expect(result).toBeUndefined();
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Expired cache entry still exists/),
+      );
+      debugSpy.mockRestore();
+    });
+
+    it("returns undefined when the stored SQL no longer matches", async () => {
+      mockKvs.entity.mockReturnValue({
+        get: vi.fn().mockResolvedValue({
+          sql: "`orders`",
+          expiration: Math.floor(DateTime.now().plus({ hours: 1 }).toSeconds()),
+          data: JSON.stringify({ id: 1 }),
+        }),
+      });
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, defaultOptions);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined on a cache miss", async () => {
+      mockKvs.entity.mockReturnValue({ get: vi.fn().mockResolvedValue(undefined) });
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, defaultOptions);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("reads from the configured custom field names", async () => {
+      const get = vi.fn().mockResolvedValue({
+        query: "`users`",
+        exp: Math.floor(DateTime.now().plus({ hours: 1 }).toSeconds()),
+        result: JSON.stringify({ id: 7 }),
+      });
+      mockKvs.entity.mockReturnValue({ get });
+
+      const result = await cache.getQueryResultsFromCache(mockQuery, {
+        ...defaultOptions,
+        cacheEntityQueryName: "query",
+        cacheEntityExpirationName: "exp",
+        cacheEntityDataName: "result",
+      });
+
+      expect(result).toEqual({ id: 7 });
+    });
+  });
+
+  describe("setQueryResult", () => {
+    const mockTransactSet = () => {
+      const set = vi.fn().mockReturnThis();
+      const execute = vi.fn().mockResolvedValue(undefined);
+      mockKvs.transact.mockReturnValue({ set, execute });
+      return { set, execute };
+    };
+
+    it("throws when cacheEntityName is not configured", async () => {
+      await expect(
+        cache.setQueryResult({ ...defaultOptions, cacheEntityName: undefined }, mockQuery, {}, 300),
+      ).rejects.toThrow("cacheEntityName is not configured");
+    });
+
+    it("skips writing when the table is queued for invalidation", async () => {
+      mockIsTableInContext.mockResolvedValue(true);
+
+      await cache.setQueryResult(defaultOptions, mockQuery, { id: 1 }, 300);
+
+      expect(mockKvs.transact).not.toHaveBeenCalled();
+    });
+
+    it("stores the serialized result with backticked tables, expiration and TTL", async () => {
+      const { set, execute } = mockTransactSet();
+      const data = { id: 1, name: "John" };
+
+      await cache.setQueryResult(defaultOptions, mockQuery, data, 300);
+
+      expect(set).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          sql: "`users`",
+          expiration: expect.any(Number),
+          data: JSON.stringify(data),
+        }),
+        { entityName: "cache" },
+        { ttl: { value: 300, unit: "SECONDS" } },
+      );
+      expect(execute).toHaveBeenCalled();
+    });
+
+    it("writes to the configured custom field names", async () => {
+      const { set } = mockTransactSet();
+
+      await cache.setQueryResult(
+        {
+          ...defaultOptions,
+          cacheEntityQueryName: "query",
+          cacheEntityExpirationName: "exp",
+          cacheEntityDataName: "result",
+        },
+        mockQuery,
+        { id: 1 },
+        300,
+      );
+
+      expect(set).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          query: "`users`",
+          exp: expect.any(Number),
+          result: JSON.stringify({ id: 1 }),
+        }),
+        { entityName: "cache" },
+        { ttl: { value: 300, unit: "SECONDS" } },
+      );
+    });
+  });
+
+  describe("clearTablesCache", () => {
+    it("throws when cacheEntityName is not configured", async () => {
+      await expect(
+        cache.clearTablesCache(["users"], { ...defaultOptions, cacheEntityName: undefined }),
+      ).rejects.toThrow("cacheEntityName is not configured");
+    });
+
+    it("deletes matched entries for every table", async () => {
+      const builder = queryBuilder([{ results: [{ key: "k1" }, { key: "k2" }], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["users", "orders"], defaultOptions);
+
+      expect(mockKvs.entity).toHaveBeenCalledWith("cache");
+      expect(builder.getMany).toHaveBeenCalledTimes(1);
+      expect(mockKvs.batchDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("wraps table names in backticks when cacheWrapTable is enabled", async () => {
+      const builder = queryBuilder([{ results: [], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["Users"], defaultOptions);
+
+      expect(mockContains).toHaveBeenCalledWith("`users`");
+    });
+
+    it("uses raw lowercased table names when cacheWrapTable is disabled", async () => {
+      const builder = queryBuilder([{ results: [], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["Users"], { ...defaultOptions, cacheWrapTable: false });
+
+      expect(mockContains).toHaveBeenCalledWith("users");
+    });
+
+    it("follows pagination cursors until exhausted", async () => {
+      const builder = queryBuilder([
+        { results: [{ key: "k1" }], nextCursor: "cursor1" },
+        { results: [{ key: "k2" }], nextCursor: null },
+      ]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["users"], defaultOptions);
+
+      expect(builder.getMany).toHaveBeenCalledTimes(2);
+      expect(mockKvs.batchDelete).toHaveBeenCalledTimes(2);
+    });
+
+    it("deletes in batches of 25", async () => {
+      const results = Array.from({ length: 30 }, (_, i) => ({ key: `k${i}` }));
+      const builder = queryBuilder([{ results, nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["users"], defaultOptions);
+
+      expect(mockKvs.batchDelete).toHaveBeenCalledTimes(2);
+      expect(mockKvs.batchDelete.mock.calls[0][0]).toHaveLength(25);
+      expect(mockKvs.batchDelete.mock.calls[1][0]).toHaveLength(5);
+    });
+
+    it("warns about keys that failed to delete", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      mockKvs.batchDelete.mockResolvedValue({ failedKeys: [{ key: "k1" }] });
+      const builder = queryBuilder([{ results: [{ key: "k1" }], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["users"], defaultOptions);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("k1"));
+      warnSpy.mockRestore();
+    });
+
+    it("logs how many records were cleared", async () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+      const builder = queryBuilder([{ results: [{ key: "k1" }], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearTablesCache(["users"], defaultOptions);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Cleared \d+ cache records in \d+ seconds/),
+      );
+      debugSpy.mockRestore();
+    });
+  });
+
+  describe("clearExpiredCache", () => {
+    it("throws when cacheEntityName is not configured", async () => {
+      await expect(
+        cache.clearExpiredCache({ ...defaultOptions, cacheEntityName: undefined }),
+      ).rejects.toThrow("cacheEntityName is not configured");
+    });
+
+    it("deletes entries whose expiration is in the past", async () => {
+      const builder = queryBuilder([
+        { results: [{ key: "expired1" }, { key: "expired2" }], nextCursor: null },
+      ]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearExpiredCache(defaultOptions);
+
+      expect(mockKvs.entity).toHaveBeenCalledWith("cache");
+      expect(mockLessThan).toHaveBeenCalled();
+      expect(mockKvs.batchDelete).toHaveBeenCalled();
+    });
+
+    it("follows pagination cursors for expired entries", async () => {
+      const builder = queryBuilder([
+        { results: [{ key: "e1" }], nextCursor: "cursor1" },
+        { results: [{ key: "e2" }], nextCursor: null },
+      ]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearExpiredCache(defaultOptions);
+
+      expect(builder.getMany).toHaveBeenCalledTimes(2);
+      expect(mockKvs.batchDelete).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs how many expired records were cleared", async () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+      const builder = queryBuilder([{ results: [{ key: "e1" }], nextCursor: null }]);
+      mockKvs.entity.mockReturnValue({ query: vi.fn().mockReturnValue(builder) });
+
+      await cache.clearExpiredCache(defaultOptions);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Cleared \d+ expired cache records in \d+ seconds/),
+      );
+      debugSpy.mockRestore();
+    });
+  });
+
+  describe("retry behavior", () => {
+    beforeEach(() => {
+      // Make backoff delays resolve immediately.
+      vi.stubGlobal("setTimeout", (callback: () => void) => {
+        callback();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("retries transient failures and succeeds", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      let attempts = 0;
+      const getMany = vi.fn().mockImplementation(() => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("Temporary error");
+        }
+        return Promise.resolve({ results: [{ key: "k1" }], nextCursor: null });
+      });
+      mockKvs.entity.mockReturnValue({
+        query: vi.fn().mockReturnValue({
+          index: vi.fn().mockReturnThis(),
+          filters: vi.fn().mockReturnThis(),
+          cursor: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          getMany,
+        }),
+      });
+
+      await cache.clearTablesCache(["users"], defaultOptions);
+
+      expect(getMany).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Error during clearing cache: Temporary error, retry \d+/),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("rejects after exhausting the maximum retry attempts", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const getMany = vi.fn().mockRejectedValue(new Error("Persistent error"));
+      mockKvs.entity.mockReturnValue({
+        query: vi.fn().mockReturnValue({
+          index: vi.fn().mockReturnThis(),
+          filters: vi.fn().mockReturnThis(),
+          cursor: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          getMany,
+        }),
+      });
+
+      await expect(cache.clearTablesCache(["users"], defaultOptions)).rejects.toThrow(
+        "Persistent error",
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Error during clearing cache: Persistent error/),
+        expect.any(Error),
+      );
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/__tests__/src/lib/cache/NopCache.test.ts
+++ b/__tests__/src/lib/cache/NopCache.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NopCache } from "../../../../src";
+
+describe("NopCache", () => {
+  let cache: NopCache;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const query = {
+    toSQL: () => ({ sql: "SELECT * FROM `users`", params: [] }),
+  } as any;
+
+  beforeEach(() => {
+    cache = new NopCache();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("getQueryResultsFromCache reports a cache miss and warns", async () => {
+    const result = await cache.getQueryResultsFromCache(query);
+
+    expect(result).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NopCache.getQueryResultsFromCache is invoked"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("SELECT * FROM `users`"));
+  });
+
+  it("setQueryResult is a no-op that resolves and warns", async () => {
+    await expect(cache.setQueryResult()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NopCache.setQueryResult is invoked"),
+    );
+  });
+
+  it("clearExpiredCache is a no-op that resolves and warns", async () => {
+    await expect(cache.clearExpiredCache()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NopCache.clearExpiredCache is invoked"),
+    );
+  });
+
+  it("clearTablesCache is a no-op that resolves and warns with the table names", async () => {
+    await expect(cache.clearTablesCache(["users", "orders"])).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NopCache.clearTablesCache is invoked for tables: users, orders"),
+    );
+  });
+});

--- a/__tests__/src/lib/drizzle/extensions/additionalActions.test.ts
+++ b/__tests__/src/lib/drizzle/extensions/additionalActions.test.ts
@@ -125,7 +125,7 @@ describe("additionalActions", () => {
     disableOptimisticLocking: false,
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     resetCacheMocks();
     // Reset cache query mocks - use mockImplementation to ensure it works correctly
@@ -133,6 +133,10 @@ describe("additionalActions", () => {
     mockGetQueryLocalCacheQuery.mockClear();
     mockSaveQueryLocalCacheQuery.mockClear();
     mockSaveQueryLocalCacheQuery.mockResolvedValue(undefined);
+    // Provide the KVS-backed cache implementation (imported dynamically so the
+    // @forge/kvs mock factory runs after its mock objects are initialized).
+    const { KVSCache } = await import("../../../../../src/lib/cache/KVSCache");
+    defaultOptions.cacheImplementation = new KVSCache();
     const baseDb = drizzle(forgeDriver);
     db = patchDbWithSelectAliased(baseDb, defaultOptions);
   });

--- a/__tests__/src/utils/cacheUtils.test.ts
+++ b/__tests__/src/utils/cacheUtils.test.ts
@@ -109,11 +109,15 @@ describe("cacheUtils", () => {
     })),
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
     mockKvs.batchDelete.mockResolvedValue({ failedKeys: [] });
+    // Delegate to the real KVS-backed cache so the @forge/kvs mocks are exercised.
+    // Imported dynamically so the @forge/kvs mock factory runs after mockKvs exists.
+    const { KVSCache } = await import("../../../src/lib/cache/KVSCache");
+    defaultOptions.cacheImplementation = new KVSCache();
   });
 
   afterEach(() => {
@@ -144,12 +148,12 @@ describe("cacheUtils", () => {
   });
 
   describe("getFromCache", () => {
-    it("should throw error when cacheEntityName is not configured", async () => {
+    it("should throw error when cacheImplementation is not configured", async () => {
       const { getFromCache } = await import("../../../src/utils/cacheUtils");
-      const options = { ...defaultOptions, cacheEntityName: undefined };
+      const options = { ...defaultOptions, cacheImplementation: undefined };
 
       await expect(getFromCache(mockQuery, options)).rejects.toThrow(
-        "cacheEntityName is not configured",
+        "cacheImplementation is not configured",
       );
     });
 
@@ -494,12 +498,12 @@ describe("cacheUtils", () => {
   });
 
   describe("setCacheResult", () => {
-    it("should throw error when cacheEntityName is not configured", async () => {
+    it("should throw error when cacheImplementation is not configured", async () => {
       const { setCacheResult } = await import("../../../src/utils/cacheUtils");
-      const options = { ...defaultOptions, cacheEntityName: undefined };
+      const options = { ...defaultOptions, cacheImplementation: undefined };
 
       await expect(setCacheResult(mockQuery, options, { id: 1 }, 300)).rejects.toThrow(
-        "cacheEntityName is not configured",
+        "cacheImplementation is not configured",
       );
     });
 
@@ -679,12 +683,12 @@ describe("cacheUtils", () => {
   });
 
   describe("clearTablesCache", () => {
-    it("should throw error when cacheEntityName is not configured", async () => {
+    it("should throw error when cacheImplementation is not configured", async () => {
       const { clearTablesCache } = await import("../../../src/utils/cacheUtils");
-      const options = { ...defaultOptions, cacheEntityName: undefined };
+      const options = { ...defaultOptions, cacheImplementation: undefined };
 
       await expect(clearTablesCache(["users"], options)).rejects.toThrow(
-        "cacheEntityName is not configured",
+        "cacheImplementation is not configured",
       );
     });
 
@@ -786,11 +790,13 @@ describe("cacheUtils", () => {
   });
 
   describe("clearExpiredCache", () => {
-    it("should throw error when cacheEntityName is not configured", async () => {
+    it("should throw error when cacheImplementation is not configured", async () => {
       const { clearExpiredCache } = await import("../../../src/utils/cacheUtils");
-      const options = { ...defaultOptions, cacheEntityName: undefined };
+      const options = { ...defaultOptions, cacheImplementation: undefined };
 
-      await expect(clearExpiredCache(options)).rejects.toThrow("cacheEntityName is not configured");
+      await expect(clearExpiredCache(options)).rejects.toThrow(
+        "cacheImplementation is not configured",
+      );
     });
 
     it("should clear expired cache entries", async () => {
@@ -975,7 +981,7 @@ describe("cacheUtils", () => {
       consoleSpy.mockRestore();
     });
 
-    it("should throw error after max retry attempts", async () => {
+    it("should log error after max retry attempts without rejecting", async () => {
       const { clearTablesCache } = await import("../../../src/utils/cacheUtils");
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1000,7 +1006,8 @@ describe("cacheUtils", () => {
         query: vi.fn().mockReturnValue(mockQueryBuilder),
       });
 
-      await expect(clearTablesCache(["users"], defaultOptions)).rejects.toThrow("Persistent error");
+      // cacheUtils.clearTablesCache swallows the error after KVSCache exhausts retries.
+      await expect(clearTablesCache(["users"], defaultOptions)).resolves.toBeUndefined();
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringMatching(/Error during clearing cache: Persistent error/),

--- a/forge-sql-orm-cli/__tests__/src/forgeSqlOrmCLI.test.ts
+++ b/forge-sql-orm-cli/__tests__/src/forgeSqlOrmCLI.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
+
+describe("forgeSqlOrmCLI entry", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.resetModules();
+    // process.exit is a no-op so the module finishes evaluating instead of aborting.
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as unknown as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  it("runs cli.mjs through tsm with forwarded args and exits 0 on success", async () => {
+    process.argv = ["node", "forgeSqlOrmCLI", "generate:model", "--host", "db"];
+
+    await import("../../src/forgeSqlOrmCLI");
+
+    expect(execSync).toHaveBeenCalledTimes(1);
+    const [command, options] = vi.mocked(execSync).mock.calls[0];
+    expect(command).toContain("tsm");
+    expect(command).toContain("cli.mjs");
+    expect(command).toContain("generate:model --host db");
+    expect(options).toEqual({ stdio: "inherit" });
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs the error and exits 1 when the command fails", async () => {
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    process.argv = ["node", "forgeSqlOrmCLI", "migrations:create"];
+
+    await import("../../src/forgeSqlOrmCLI");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Command execution failed"),
+      "boom",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("logs the raw value when a non-Error is thrown and exits 1", async () => {
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw "string failure";
+    });
+    process.argv = ["node", "forgeSqlOrmCLI", "migrations:drop"];
+
+    await import("../../src/forgeSqlOrmCLI");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Command execution failed"),
+      "string failure",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/forge-sql-orm-cli/vitest.config.mts
+++ b/forge-sql-orm-cli/vitest.config.mts
@@ -8,7 +8,6 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       include: ["src"],
-      exclude: ["src/forgeSqlOrmCLI.mts"],
       reportsDirectory: './coverage',
       thresholds: {
         statements: 80,

--- a/src/core/ForgeSQLORM.ts
+++ b/src/core/ForgeSQLORM.ts
@@ -51,6 +51,7 @@ import { operationTypeQueryContext } from "../utils/requestTypeContextUtils";
 import { getErrorMessage } from "../utils/errorUtils";
 import type { MySqlQueryResultKind } from "drizzle-orm/mysql-core/session";
 import { Rovo } from "./Rovo";
+import { KVSCache } from "../lib/cache/KVSCache";
 
 /**
  * Implementation of ForgeSQLORM that uses Drizzle ORM for query building.
@@ -93,6 +94,7 @@ class ForgeSQLORMImpl implements ForgeSqlOperation {
         cacheEntityQueryName: "sql",
         cacheEntityExpirationName: "expiration",
         cacheEntityDataName: "data",
+        cacheImplementation: new KVSCache(),
       };
       this.options = newOptions;
       if (newOptions.logRawSqlQuery) {

--- a/src/core/ForgeSQLQueryBuilder.ts
+++ b/src/core/ForgeSQLQueryBuilder.ts
@@ -43,6 +43,7 @@ import {
   SelectAllFromAliasedType,
   SelectAllFromCacheableAliasedType,
   UpdateAndEvictCacheType,
+  Cache,
 } from "..";
 import {
   MySqlDeleteBase,
@@ -1261,7 +1262,7 @@ export interface ForgeSqlOrmOptions {
   cacheEntityExpirationName?: string;
   /** Name of the field in cache entity that stores cached data */
   cacheEntityDataName?: string;
-
+  cacheImplementation?: Cache;
   /**
    * Additional metadata for table configuration.
    * Allows specifying table-specific settings and behaviors such as version fields for optimistic locking.

--- a/src/lib/cache/Cache.ts
+++ b/src/lib/cache/Cache.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { ForgeSqlOrmOptions } from "../../core";
+import { Query } from "drizzle-orm";
+
+/**
+ * Service Provider Interface (SPI) for the query-result cache used by ForgeSQL ORM.
+ *
+ * A cache stores the results of read queries keyed by their SQL and parameters, and
+ * invalidates those results when the underlying tables change or entries expire.
+ * The ORM never talks to a storage backend directly: it always goes through this
+ * interface, so a backend (for example Forge KVS) can be plugged in via
+ * {@link ForgeSqlOrmOptions.cacheImplementation} without changing ORM code.
+ *
+ * Implementations are responsible for choosing the storage backend, computing cache
+ * keys, honouring the TTL and respecting the field names configured in
+ * {@link ForgeSqlOrmOptions} (such as `cacheEntityName`).
+ */
+export interface Cache {
+  /**
+   * Returns the cached result for a query, or `undefined` on a cache miss.
+   *
+   * The query's SQL and parameters identify the entry. Expired entries and entries
+   * whose table is currently scheduled for invalidation must be treated as a miss.
+   *
+   * @typeParam T - Expected shape of the cached result.
+   * @param query - Query whose `toSQL()` output is used to build the cache key.
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   * @returns The cached result, or `undefined` if absent, expired or stale.
+   */
+  getQueryResultsFromCache<T>(
+    query: { toSQL: () => Query },
+    options: ForgeSqlOrmOptions,
+  ): Promise<T | undefined>;
+
+  /**
+   * Stores the result of a query in the cache with the given time-to-live.
+   *
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   * @param query - Query whose `toSQL()` output is used to build the cache key.
+   * @param results - The query result to cache (serialized by the implementation).
+   * @param ttl - Time-to-live in seconds for the stored entry.
+   */
+  setQueryResult(
+    options: ForgeSqlOrmOptions,
+    query: { toSQL: () => Query },
+    results: unknown,
+    ttl: number,
+  ): Promise<void>;
+
+  /**
+   * Removes expired entries from the cache backend.
+   *
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   */
+  clearExpiredCache(options: ForgeSqlOrmOptions): Promise<void>;
+
+  /**
+   * Removes every cached entry that references any of the given tables, so that
+   * subsequent reads of those tables are served fresh.
+   *
+   * @param tables - Names of the tables whose cached entries must be evicted.
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   */
+  clearTablesCache(tables: string[], options: ForgeSqlOrmOptions): Promise<void>;
+}

--- a/src/lib/cache/KVSCache.ts
+++ b/src/lib/cache/KVSCache.ts
@@ -106,9 +106,9 @@ export class KVSCache implements Cache {
       const batchResult = await kvs.batchDelete(
         batch.map((result) => ({ key: result.key, entityName: cacheEntityName })),
       );
-      batchResult.failedKeys.forEach((failedKey) =>
-        warnCacheLog(JSON.stringify(failedKey), options),
-      );
+      batchResult.failedKeys.forEach((failedKey) => {
+        warnCacheLog(JSON.stringify(failedKey), options);
+      });
     }
   }
 

--- a/src/lib/cache/KVSCache.ts
+++ b/src/lib/cache/KVSCache.ts
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { Cache } from "./Cache";
+import { ForgeSqlOrmOptions } from "../..";
+import { Filter, FilterConditions, kvs, WhereConditions } from "@forge/kvs";
+import { extractBacktickedValues } from "../../utils/cacheTableUtils";
+import { Query } from "drizzle-orm";
+import { isTableContainsTableInCacheContext } from "../../utils/cacheContextUtils";
+import { debugCacheLog, warnCacheLog, hashKey } from "../../utils/cacheUtils";
+import { DateTime } from "luxon";
+import { getErrorMessage } from "../../utils/errorUtils";
+
+const CACHE_CONSTANTS = {
+  BATCH_SIZE: 25,
+  MAX_RETRY_ATTEMPTS: 3,
+  INITIAL_RETRY_DELAY: 1000,
+  RETRY_DELAY_MULTIPLIER: 2,
+  DEFAULT_ENTITY_QUERY_NAME: "sql",
+  DEFAULT_EXPIRATION_NAME: "expiration",
+  DEFAULT_DATA_NAME: "data",
+  PAGE_SIZE: 100,
+} as const;
+
+type CacheEntity = {
+  [key: string]: string | number;
+};
+
+/** Names of the cache entity fields, resolved from options with defaults applied. */
+type ResolvedFieldNames = {
+  entityQueryName: string;
+  expirationName: string;
+  dataName: string;
+};
+
+/** A page of cache keys returned by a KVS query, with an optional pagination cursor. */
+type CacheKeyPage = {
+  results: Array<{ key: string }>;
+  nextCursor?: string;
+};
+
+/**
+ * Current Unix time in whole seconds.
+ *
+ * @returns Current timestamp as an integer number of seconds.
+ */
+function nowSeconds(): number {
+  return Math.floor(DateTime.now().toSeconds());
+}
+
+/**
+ * Computes a future timestamp by adding seconds to the current time.
+ *
+ * @param secondsToAdd - Number of seconds to add to the current time.
+ * @returns Future timestamp in whole seconds.
+ */
+function nowPlusSeconds(secondsToAdd: number): number {
+  return Math.floor(DateTime.now().plus({ seconds: secondsToAdd }).toSeconds());
+}
+
+/**
+ * {@link Cache} implementation backed by the Atlassian Forge KVS custom entity store.
+ *
+ * Query results are stored as custom entities keyed by {@link hashKey}, with a TTL and
+ * an expiration timestamp. Reads verify both the expiration and the originating SQL so
+ * that stale or hash-colliding entries are ignored. Invalidation and expired-entry
+ * cleanup use cursor-based pagination and batched deletes to stay within Forge limits,
+ * and transient KVS failures are retried with exponential backoff.
+ */
+export class KVSCache implements Cache {
+  /**
+   * Returns the configured cache entity name, throwing when caching is not configured.
+   */
+  private requireEntityName(options: ForgeSqlOrmOptions): string {
+    if (!options.cacheEntityName) {
+      throw new Error("cacheEntityName is not configured");
+    }
+    return options.cacheEntityName;
+  }
+
+  /**
+   * Resolves the cache entity field names from options, applying defaults.
+   */
+  private resolveFieldNames(options: ForgeSqlOrmOptions): ResolvedFieldNames {
+    return {
+      entityQueryName: options.cacheEntityQueryName ?? CACHE_CONSTANTS.DEFAULT_ENTITY_QUERY_NAME,
+      expirationName: options.cacheEntityExpirationName ?? CACHE_CONSTANTS.DEFAULT_EXPIRATION_NAME,
+      dataName: options.cacheEntityDataName ?? CACHE_CONSTANTS.DEFAULT_DATA_NAME,
+    };
+  }
+
+  /**
+   * Deletes cache entries in batches to respect Forge limits and timeouts.
+   *
+   * @param results - Array of cache entries to delete.
+   * @param cacheEntityName - Name of the cache entity.
+   * @param options - Forge SQL ORM options used for logging.
+   */
+  private async deleteCacheEntriesInBatches(
+    results: Array<{ key: string }>,
+    cacheEntityName: string,
+    options?: ForgeSqlOrmOptions,
+  ): Promise<void> {
+    for (let i = 0; i < results.length; i += CACHE_CONSTANTS.BATCH_SIZE) {
+      const batch = results.slice(i, i + CACHE_CONSTANTS.BATCH_SIZE);
+      const batchResult = await kvs.batchDelete(
+        batch.map((result) => ({ key: result.key, entityName: cacheEntityName })),
+      );
+      batchResult.failedKeys.forEach((failedKey) =>
+        warnCacheLog(JSON.stringify(failedKey), options),
+      );
+    }
+  }
+
+  /**
+   * Drains a KVS query page by page, deleting every matched entry, and returns the
+   * total number of deleted entries.
+   *
+   * @param baseQuery - Query builder configured with the index and filters to drain.
+   * @param cacheEntityName - Name of the cache entity being cleared.
+   * @param options - ForgeSQL ORM options used for logging.
+   * @param label - Human-readable label used in debug logs.
+   * @returns Total number of deleted cache entries.
+   */
+  private async drainAndDelete<
+    Q extends {
+      cursor(cursor: string): Q;
+      limit(limit: number): { getMany(): Promise<CacheKeyPage> };
+    },
+  >(
+    baseQuery: Q,
+    cacheEntityName: string,
+    options: ForgeSqlOrmOptions,
+    label: string,
+  ): Promise<number> {
+    let cursor = "";
+    let total = 0;
+
+    for (;;) {
+      const activeQuery = cursor ? baseQuery.cursor(cursor) : baseQuery;
+      const listResult = await activeQuery.limit(CACHE_CONSTANTS.PAGE_SIZE).getMany();
+
+      debugCacheLog(`${label}: ${JSON.stringify(listResult.results.map((r) => r.key))}`, options);
+      await this.deleteCacheEntriesInBatches(listResult.results, cacheEntityName, options);
+      total += listResult.results.length;
+
+      if (!listResult.nextCursor) {
+        return total;
+      }
+      cursor = listResult.nextCursor;
+    }
+  }
+
+  /**
+   * Executes an operation with retry and exponential backoff on failure.
+   *
+   * @param operation - Operation to execute.
+   * @param operationName - Name of the operation, used in log messages.
+   * @returns The operation result once it succeeds.
+   * @throws The last error if all retry attempts are exhausted.
+   */
+  private async executeWithRetry<T>(
+    operation: () => Promise<T>,
+    operationName: string,
+  ): Promise<T> {
+    let attempt = 0;
+    let delay = CACHE_CONSTANTS.INITIAL_RETRY_DELAY;
+
+    while (attempt < CACHE_CONSTANTS.MAX_RETRY_ATTEMPTS) {
+      try {
+        return await operation();
+      } catch (err) {
+        const message = getErrorMessage(err);
+        // eslint-disable-next-line no-console
+        console.warn(`Error during ${operationName}: ${message}, retry ${attempt}`, err);
+        attempt++;
+
+        if (attempt >= CACHE_CONSTANTS.MAX_RETRY_ATTEMPTS) {
+          // eslint-disable-next-line no-console
+          console.error(`Error during ${operationName}: ${message}`, err);
+          throw err;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= CACHE_CONSTANTS.RETRY_DELAY_MULTIPLIER;
+      }
+    }
+
+    throw new Error(`Maximum retry attempts exceeded for ${operationName}`);
+  }
+
+  /**
+   * Runs a clearing operation with retry and logs how many entries were removed and
+   * how long it took.
+   *
+   * @param operationName - Operation name used for retry logging.
+   * @param recordNoun - Noun describing the cleared records, used in the summary log.
+   * @param options - ForgeSQL ORM options used for logging.
+   * @param operation - Clearing operation returning the number of deleted entries.
+   */
+  private async runClear(
+    operationName: string,
+    recordNoun: string,
+    options: ForgeSqlOrmOptions,
+    operation: () => Promise<number>,
+  ): Promise<void> {
+    const startTime = DateTime.now();
+    let totalRecords = 0;
+
+    try {
+      totalRecords = await this.executeWithRetry(operation, operationName);
+    } finally {
+      const duration = DateTime.now().toSeconds() - startTime.toSeconds();
+      debugCacheLog(`Cleared ${totalRecords} ${recordNoun} in ${duration} seconds`, options);
+    }
+  }
+
+  /**
+   * Evicts every cached entry whose stored SQL references any of the given tables.
+   *
+   * @param tables - Names of the tables whose cached entries must be evicted.
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   */
+  async clearTablesCache(tables: string[], options: ForgeSqlOrmOptions): Promise<void> {
+    const cacheEntityName = this.requireEntityName(options);
+    const { entityQueryName } = this.resolveFieldNames(options);
+
+    const filters = new Filter<{ [entityQueryName]: string }>();
+    for (const table of tables) {
+      const wrapIfNeeded = options.cacheWrapTable ? `\`${table}\`` : table;
+      filters.or(entityQueryName, FilterConditions.contains(wrapIfNeeded?.toLowerCase()));
+    }
+
+    const baseQuery = kvs
+      .entity<{ [entityQueryName]: string }>(cacheEntityName)
+      .query()
+      .index(entityQueryName)
+      .filters(filters);
+
+    await this.runClear("clearing cache", "cache records", options, () =>
+      this.drainAndDelete(baseQuery, cacheEntityName, options, "clear cache Records"),
+    );
+  }
+
+  /**
+   * Removes cache entries whose expiration timestamp is already in the past.
+   *
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   */
+  async clearExpiredCache(options: ForgeSqlOrmOptions): Promise<void> {
+    const cacheEntityName = this.requireEntityName(options);
+    const { expirationName } = this.resolveFieldNames(options);
+
+    const baseQuery = kvs
+      .entity<{ [expirationName]: number }>(cacheEntityName)
+      .query()
+      .index(expirationName)
+      .where(WhereConditions.lessThan(nowSeconds()));
+
+    await this.runClear("clearing expired cache", "expired cache records", options, () =>
+      this.drainAndDelete(baseQuery, cacheEntityName, options, "clear expired Records"),
+    );
+  }
+
+  /**
+   * Returns the cached result for a query, or `undefined` when it is missing, expired,
+   * stale (the stored SQL no longer matches), or its table is pending invalidation.
+   *
+   * @typeParam T - Expected shape of the cached result.
+   * @param query - Query whose `toSQL()` output identifies the cache entry.
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   * @returns The cached result, or `undefined`.
+   */
+  async getQueryResultsFromCache<T>(
+    query: { toSQL: () => Query },
+    options: ForgeSqlOrmOptions,
+  ): Promise<T | undefined> {
+    const cacheEntityName = this.requireEntityName(options);
+    const { entityQueryName, expirationName, dataName } = this.resolveFieldNames(options);
+
+    const sqlQuery = query.toSQL();
+    const key = hashKey(sqlQuery);
+
+    // Skip cache if the table is queued for invalidation in the current context.
+    if (await isTableContainsTableInCacheContext(sqlQuery.sql, options)) {
+      debugCacheLog("Context contains value to clear. Skip getting from cache", options);
+      return undefined;
+    }
+
+    const cacheResult = await kvs.entity<CacheEntity>(cacheEntityName).get(key);
+    if (!cacheResult) {
+      return undefined;
+    }
+
+    const notExpired = (cacheResult[expirationName] as number) >= nowSeconds();
+    const matchesQuery =
+      extractBacktickedValues(sqlQuery.sql, options) === cacheResult[entityQueryName];
+    if (notExpired && matchesQuery) {
+      debugCacheLog(`Get value from cache, cacheKey: ${key}`, options);
+      return JSON.parse(cacheResult[dataName] as string);
+    }
+
+    debugCacheLog(
+      `Expired cache entry still exists (will be automatically removed within 48 hours per Forge KVS TTL documentation), cacheKey: ${key}`,
+      options,
+    );
+    return undefined;
+  }
+
+  /**
+   * Stores a query result in the cache with the given TTL, skipping the write when the
+   * table is queued for invalidation in the current context.
+   *
+   * @param options - ForgeSQL ORM options describing the cache backend.
+   * @param query - Query whose `toSQL()` output identifies the cache entry.
+   * @param results - The query result to cache.
+   * @param ttl - Time-to-live in seconds; falls back to `options.cacheTTL`.
+   */
+  async setQueryResult(
+    options: ForgeSqlOrmOptions,
+    query: { toSQL: () => Query },
+    results: unknown,
+    ttl: number,
+  ): Promise<void> {
+    const cacheEntityName = this.requireEntityName(options);
+    const { entityQueryName, expirationName, dataName } = this.resolveFieldNames(options);
+
+    const sqlQuery = query.toSQL();
+
+    // Skip cache if the table is queued for invalidation in the current context.
+    if (await isTableContainsTableInCacheContext(sqlQuery.sql, options)) {
+      debugCacheLog("Context contains value to clear. Skip setting from cache", options);
+      return;
+    }
+
+    const key = hashKey(sqlQuery);
+    const cacheTTLValue = ttl ?? options.cacheTTL;
+
+    await kvs
+      .transact()
+      .set(
+        key,
+        {
+          [entityQueryName]: extractBacktickedValues(sqlQuery.sql, options),
+          [expirationName]: nowPlusSeconds(cacheTTLValue),
+          [dataName]: JSON.stringify(results),
+        },
+        { entityName: cacheEntityName },
+        { ttl: { value: cacheTTLValue, unit: "SECONDS" } },
+      )
+      .execute();
+    debugCacheLog(`Store value to cache, cacheKey: ${key}`, options);
+  }
+}

--- a/src/lib/cache/NopCache.ts
+++ b/src/lib/cache/NopCache.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { Cache } from "./Cache";
+import { Query } from "drizzle-orm";
+
+/**
+ * No-op {@link Cache} implementation used as the default when no caching backend
+ * is configured.
+ *
+ * Every method is a safe stub: reads always report a cache miss and writes and
+ * invalidations do nothing. Each call emits a `console.warn` so that caching being
+ * effectively disabled is visible during development and points to a missing
+ * {@link ForgeSqlOrmOptions.cacheImplementation} configuration.
+ */
+export class NopCache implements Cache {
+  /**
+   * No-op table invalidation; warns that caching is not configured.
+   */
+  async clearTablesCache(tables: string[]): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `NopCache.clearTablesCache is invoked for tables: ${tables.join(", ")}. Please check your configuration.`,
+    );
+  }
+
+  /**
+   * Always reports a cache miss; warns that caching is not configured.
+   */
+  async getQueryResultsFromCache<T>(query: { toSQL: () => Query }): Promise<T | undefined> {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `NopCache.getQueryResultsFromCache is invoked for query: ${query.toSQL().sql}. Please check your configuration.`,
+    );
+    return undefined;
+  }
+
+  /**
+   * No-op expired-entry cleanup; warns that caching is not configured.
+   */
+  async clearExpiredCache(): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.warn("NopCache.clearExpiredCache is invoked. Please check your configuration.");
+  }
+
+  /**
+   * No-op result storage; warns that caching is not configured.
+   */
+  async setQueryResult(): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.warn("NopCache.setQueryResult is invoked. Please check your configuration.");
+  }
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
 // SPDX-License-Identifier: MIT
 
-export * from "./drizzle/extensions/additionalActions";
-export * from "./cache";
+export * from "./Cache";
+export * from "./NopCache";
+export * from "./KVSCache";

--- a/src/utils/cacheContextUtils.ts
+++ b/src/utils/cacheContextUtils.ts
@@ -6,8 +6,8 @@ import { AnyMySqlSelectQueryBuilder, AnyMySqlTable } from "drizzle-orm/mysql-cor
 import { getTableName } from "drizzle-orm/table";
 import { ForgeSqlOrmOptions } from "../core";
 import { MySqlSelectDynamic } from "drizzle-orm/mysql-core/query-builders/select.types";
-import { hashKey } from "./cacheUtils";
 import { Query } from "drizzle-orm/sql/sql";
+import { hashKey } from "./cacheUtils";
 
 /**
  * Interface representing the cache application context.

--- a/src/utils/cacheUtils.ts
+++ b/src/utils/cacheUtils.ts
@@ -1,56 +1,17 @@
 // SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
 // SPDX-License-Identifier: MIT
 
-import { DateTime } from "luxon";
-import * as crypto from "node:crypto";
 import { Query } from "drizzle-orm";
 import { AnyMySqlTable } from "drizzle-orm/mysql-core";
 import { getTableName } from "drizzle-orm/table";
-import { Filter, FilterConditions, kvs, WhereConditions } from "@forge/kvs";
 import { ForgeSqlOrmOptions } from "../core";
-import { cacheApplicationContext, isTableContainsTableInCacheContext } from "./cacheContextUtils";
-import { extractBacktickedValues } from "./cacheTableUtils";
+import { cacheApplicationContext } from "./cacheContextUtils";
 import { getErrorMessage } from "./errorUtils";
+import * as crypto from "node:crypto";
 
-// Constants for better maintainability
-const CACHE_CONSTANTS = {
-  BATCH_SIZE: 25,
-  MAX_RETRY_ATTEMPTS: 3,
-  INITIAL_RETRY_DELAY: 1000,
-  RETRY_DELAY_MULTIPLIER: 2,
-  DEFAULT_ENTITY_QUERY_NAME: "sql",
-  DEFAULT_EXPIRATION_NAME: "expiration",
-  DEFAULT_DATA_NAME: "data",
+const SHARED_CACHE_CONSTANTS = {
   HASH_LENGTH: 32,
 } as const;
-
-// Types for better type safety
-type CacheEntity = {
-  [key: string]: string | number;
-};
-
-/**
- * Gets the current Unix timestamp in seconds.
- *
- * @returns Current timestamp as integer
- */
-function getCurrentTime(): number {
-  const dt = DateTime.now();
-  return Math.floor(dt.toSeconds());
-}
-
-/**
- * Calculates a future timestamp by adding seconds to the current time.
- * Validates that the result is within 32-bit integer range.
- *
- * @param secondsToAdd - Number of seconds to add to current time
- * @returns Future timestamp in seconds
- * @throws Error if the result is out of 32-bit integer range
- */
-function nowPlusSeconds(secondsToAdd: number): number {
-  const dt = DateTime.now().plus({ seconds: secondsToAdd });
-  return Math.floor(dt.toSeconds());
-}
 
 /**
  * Logs a message to console.debug when options.logCache is enabled.
@@ -58,195 +19,24 @@ function nowPlusSeconds(secondsToAdd: number): number {
  * @param message - Message to log
  * @param options - ForgeSQL ORM options (optional)
  */
-function debugLog(message: string, options?: ForgeSqlOrmOptions): void {
+export function debugCacheLog(message: string, options?: ForgeSqlOrmOptions): void {
   if (options?.logCache) {
     // eslint-disable-next-line no-console
     console.debug(message);
   }
-} /**
- * Logs a message to console.debug when options.logCache is enabled.
+}
+
+/**
+ * Logs a message to console.warn when options.logCache is enabled.
  *
  * @param message - Message to log
  * @param options - ForgeSQL ORM options (optional)
  */
-function warnLog(message: string, options?: ForgeSqlOrmOptions): void {
+export function warnCacheLog(message: string, options?: ForgeSqlOrmOptions): void {
   if (options?.logCache) {
     // eslint-disable-next-line no-console
     console.warn(message);
   }
-}
-
-/**
- * Generates a hash key for a query based on its SQL and parameters.
- *
- * @param query - The Drizzle query object
- * @returns 32-character hexadecimal hash
- */
-export function hashKey(query: Query): string {
-  const h = crypto.createHash("sha256");
-  h.update(query.sql.toLowerCase());
-  h.update(JSON.stringify(query.params));
-  return "CachedQuery_" + h.digest("hex").slice(0, CACHE_CONSTANTS.HASH_LENGTH);
-}
-
-/**
- * Deletes cache entries in batches to respect Forge limits and timeouts.
- *
- * @param results - Array of cache entries to delete
- * @param cacheEntityName - Name of the cache entity
- * @param options - Forge SQL ORM properties
- * @returns Promise that resolves when all deletions are complete
- */
-async function deleteCacheEntriesInBatches(
-  results: Array<{ key: string }>,
-  cacheEntityName: string,
-  options?: ForgeSqlOrmOptions,
-): Promise<void> {
-  for (let i = 0; i < results.length; i += CACHE_CONSTANTS.BATCH_SIZE) {
-    const batch = results.slice(i, i + CACHE_CONSTANTS.BATCH_SIZE);
-    const batchResult = await kvs.batchDelete(
-      batch.map((result) => ({ key: result.key, entityName: cacheEntityName })),
-    );
-    batchResult.failedKeys.forEach((failedKey) => warnLog(JSON.stringify(failedKey), options));
-  }
-}
-
-/**
- * Clears cache entries for specific tables using cursor-based pagination.
- *
- * @param tables - Array of table names to clear cache for
- * @param cursor - Pagination cursor for large result sets
- * @param options - ForgeSQL ORM options
- * @returns Total number of deleted cache entries
- */
-async function clearCursorCache(
-  tables: string[],
-  cursor: string,
-  options: ForgeSqlOrmOptions,
-): Promise<number> {
-  const cacheEntityName = options.cacheEntityName;
-  if (!cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
-  }
-
-  const entityQueryName = options.cacheEntityQueryName ?? CACHE_CONSTANTS.DEFAULT_ENTITY_QUERY_NAME;
-  let filters = new Filter<{
-    [entityQueryName]: string;
-  }>();
-
-  for (const table of tables) {
-    const wrapIfNeeded = options.cacheWrapTable ? `\`${table}\`` : table;
-    filters.or(entityQueryName, FilterConditions.contains(wrapIfNeeded?.toLowerCase()));
-  }
-
-  let entityQueryBuilder = kvs
-    .entity<{
-      [entityQueryName]: string;
-    }>(cacheEntityName)
-    .query()
-    .index(entityQueryName)
-    .filters(filters);
-
-  if (cursor) {
-    entityQueryBuilder = entityQueryBuilder.cursor(cursor);
-  }
-
-  const listResult = await entityQueryBuilder.limit(100).getMany();
-
-  debugLog(`clear cache Records: ${JSON.stringify(listResult.results.map((r) => r.key))}`, options);
-
-  await deleteCacheEntriesInBatches(listResult.results, cacheEntityName, options);
-
-  if (listResult.nextCursor) {
-    return (
-      listResult.results.length + (await clearCursorCache(tables, listResult.nextCursor, options))
-    );
-  } else {
-    return listResult.results.length;
-  }
-}
-
-/**
- * Clears expired cache entries using cursor-based pagination.
- *
- * @param cursor - Pagination cursor for large result sets
- * @param options - ForgeSQL ORM options
- * @returns Total number of deleted expired cache entries
- */
-async function clearExpirationCursorCache(
-  cursor: string,
-  options: ForgeSqlOrmOptions,
-): Promise<number> {
-  const cacheEntityName = options.cacheEntityName;
-  if (!cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
-  }
-
-  const entityExpirationName =
-    options.cacheEntityExpirationName ?? CACHE_CONSTANTS.DEFAULT_EXPIRATION_NAME;
-  let entityQueryBuilder = kvs
-    .entity<{
-      [entityExpirationName]: number;
-    }>(cacheEntityName)
-    .query()
-    .index(entityExpirationName)
-    .where(WhereConditions.lessThan(Math.floor(DateTime.now().toSeconds())));
-
-  if (cursor) {
-    entityQueryBuilder = entityQueryBuilder.cursor(cursor);
-  }
-
-  const listResult = await entityQueryBuilder.limit(100).getMany();
-
-  debugLog(
-    `clear expired Records: ${JSON.stringify(listResult.results.map((r) => r.key))}`,
-    options,
-  );
-
-  await deleteCacheEntriesInBatches(listResult.results, cacheEntityName);
-
-  if (listResult.nextCursor) {
-    return (
-      listResult.results.length + (await clearExpirationCursorCache(listResult.nextCursor, options))
-    );
-  } else {
-    return listResult.results.length;
-  }
-}
-
-/**
- * Executes a function with retry logic and exponential backoff.
- *
- * @param operation - Function to execute with retry
- * @param operationName - Name of the operation for logging
- * @param options - ForgeSQL ORM options for logging
- * @returns Promise that resolves to the operation result
- */
-async function executeWithRetry<T>(operation: () => Promise<T>, operationName: string): Promise<T> {
-  let attempt = 0;
-  let delay = CACHE_CONSTANTS.INITIAL_RETRY_DELAY;
-
-  while (attempt < CACHE_CONSTANTS.MAX_RETRY_ATTEMPTS) {
-    try {
-      return await operation();
-    } catch (err) {
-      const message = getErrorMessage(err);
-      // eslint-disable-next-line no-console
-      console.warn(`Error during ${operationName}: ${message}, retry ${attempt}`, err);
-      attempt++;
-
-      if (attempt >= CACHE_CONSTANTS.MAX_RETRY_ATTEMPTS) {
-        // eslint-disable-next-line no-console
-        console.error(`Error during ${operationName}: ${message}`, err);
-        throw err;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      delay *= CACHE_CONSTANTS.RETRY_DELAY_MULTIPLIER;
-    }
-  }
-
-  throw new Error(`Maximum retry attempts exceeded for ${operationName}`);
 }
 
 /**
@@ -279,21 +69,15 @@ export async function clearTablesCache(
   tables: string[],
   options: ForgeSqlOrmOptions,
 ): Promise<void> {
-  if (!options.cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
+  if (!options.cacheImplementation) {
+    throw new Error("cacheImplementation is not configured");
   }
 
-  const startTime = DateTime.now();
-  let totalRecords = 0;
-
   try {
-    totalRecords = await executeWithRetry(
-      () => clearCursorCache(tables, "", options),
-      "clearing cache",
-    );
-  } finally {
-    const duration = DateTime.now().toSeconds() - startTime.toSeconds();
-    debugLog(`Cleared ${totalRecords} cache records in ${duration} seconds`, options);
+    return await options.cacheImplementation.clearTablesCache(tables, options);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error clear cache: ${getErrorMessage(error)}`, error);
   }
 }
 /**
@@ -304,21 +88,15 @@ export async function clearTablesCache(
  * @returns Promise that resolves when expired cache clearing is complete
  */
 export async function clearExpiredCache(options: ForgeSqlOrmOptions): Promise<void> {
-  if (!options.cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
+  if (!options.cacheImplementation) {
+    throw new Error("cacheImplementation is not configured");
   }
 
-  const startTime = DateTime.now();
-  let totalRecords = 0;
-
   try {
-    totalRecords = await executeWithRetry(
-      () => clearExpirationCursorCache("", options),
-      "clearing expired cache",
-    );
-  } finally {
-    const duration = DateTime.now().toSeconds() - startTime.toSeconds();
-    debugLog(`Cleared ${totalRecords} expired cache records in ${duration} seconds`, options);
+    return await options.cacheImplementation.clearExpiredCache(options);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error getting from cache: ${getErrorMessage(error)}`, error);
   }
 }
 
@@ -337,42 +115,12 @@ export async function getFromCache<T>(
   query: { toSQL: () => Query },
   options: ForgeSqlOrmOptions,
 ): Promise<T | undefined> {
-  if (!options.cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
-  }
-
-  const entityQueryName = options.cacheEntityQueryName ?? CACHE_CONSTANTS.DEFAULT_ENTITY_QUERY_NAME;
-  const expirationName =
-    options.cacheEntityExpirationName ?? CACHE_CONSTANTS.DEFAULT_EXPIRATION_NAME;
-  const dataName = options.cacheEntityDataName ?? CACHE_CONSTANTS.DEFAULT_DATA_NAME;
-
-  const sqlQuery = query.toSQL();
-  const key = hashKey(sqlQuery);
-
-  // Skip cache if table is in cache context (will be cleared)
-  if (await isTableContainsTableInCacheContext(sqlQuery.sql, options)) {
-    debugLog("Context contains value to clear. Skip getting from cache", options);
-    return undefined;
+  if (!options.cacheImplementation) {
+    throw new Error("cacheImplementation is not configured");
   }
 
   try {
-    const cacheResult = await kvs.entity<CacheEntity>(options.cacheEntityName).get(key);
-
-    if (cacheResult) {
-      if (
-        (cacheResult[expirationName] as number) >= getCurrentTime() &&
-        extractBacktickedValues(sqlQuery.sql, options) === cacheResult[entityQueryName]
-      ) {
-        debugLog(`Get value from cache, cacheKey: ${key}`, options);
-        const results = cacheResult[dataName];
-        return JSON.parse(results as string);
-      } else {
-        debugLog(
-          `Expired cache entry still exists (will be automatically removed within 48 hours per Forge KVS TTL documentation), cacheKey: ${key}`,
-          options,
-        );
-      }
-    }
+    return await options.cacheImplementation.getQueryResultsFromCache(query, options);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`Error getting from cache: ${getErrorMessage(error)}`, error);
@@ -403,44 +151,27 @@ export async function setCacheResult(
   results: unknown,
   cacheTtl: number,
 ): Promise<void> {
-  if (!options.cacheEntityName) {
-    throw new Error("cacheEntityName is not configured");
+  if (!options.cacheImplementation) {
+    throw new Error("cacheImplementation is not configured");
   }
 
   try {
-    const entityQueryName =
-      options.cacheEntityQueryName ?? CACHE_CONSTANTS.DEFAULT_ENTITY_QUERY_NAME;
-    const expirationName =
-      options.cacheEntityExpirationName ?? CACHE_CONSTANTS.DEFAULT_EXPIRATION_NAME;
-    const dataName = options.cacheEntityDataName ?? CACHE_CONSTANTS.DEFAULT_DATA_NAME;
-
-    const sqlQuery = query.toSQL();
-
-    // Skip cache if table is in cache context (will be cleared)
-    if (await isTableContainsTableInCacheContext(sqlQuery.sql, options)) {
-      debugLog("Context contains value to clear. Skip setting from cache", options);
-      return;
-    }
-
-    const key = hashKey(sqlQuery);
-
-    await kvs
-      .transact()
-      .set(
-        key,
-        {
-          [entityQueryName]: extractBacktickedValues(sqlQuery.sql, options),
-          [expirationName]: nowPlusSeconds(cacheTtl + 2),
-          [dataName]: JSON.stringify(results),
-        },
-        { entityName: options.cacheEntityName },
-        { ttl: { value: cacheTtl, unit: "SECONDS" } },
-      )
-      .execute();
-
-    debugLog(`Store value to cache, cacheKey: ${key}`, options);
+    await options.cacheImplementation.setQueryResult(options, query, results, cacheTtl);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`Error setting cache: ${getErrorMessage(error)}`, error);
   }
+}
+
+/**
+ * Generates a stable cache key for a query based on its SQL and parameters.
+ *
+ * @param query - The Drizzle query object.
+ * @returns A `CachedQuery_`-prefixed 32-character hexadecimal hash.
+ */
+export function hashKey(query: Query): string {
+  const h = crypto.createHash("sha256");
+  h.update(query.sql.toLowerCase());
+  h.update(JSON.stringify(query.params));
+  return "CachedQuery_" + h.digest("hex").slice(0, SHARED_CACHE_CONSTANTS.HASH_LENGTH);
 }


### PR DESCRIPTION


- Added `Cache` interface to abstract caching logic for ForgeSQL ORM.
- Introduced `KVSCache` and `NopCache` implementations for configurable caching backends.
- Updated `ForgeSQLORM` to use `KVSCache` as the default cache implementation.
- Simplified cache-related utility functions and centralized caching logic.
- Enhanced configuration flexibility by delegating caching operations to the selected backend.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable cache backend with built-in KVS-backed and no-op implementations; default retains prior KVS behavior.

* **Documentation**
  * README updated with migration guidance and a new option documenting configurable cache implementation, defaults, and examples.

* **Refactor**
  * Cache operations delegated to the configurable cache implementation and public cache API added/re-exported.

* **Tests**
  * Extensive new and updated test suites covering cache implementations, CLI behavior, and related utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->