### PR TITLE
ci: add weekly GPR publishing workflow and versioning logic

### DIFF
--- a/.github/workflows/weekly-gpr.yml
+++ b/.github/workflows/weekly-gpr.yml
@@ -116,6 +116,12 @@ jobs:
           node scripts/ci/github-packages.mjs publish-weekly-cli "${{ steps.publish_weekly_core.outputs.core_version }}"
           echo "cli_version=$(node scripts/ci/github-packages.mjs weekly-version forge-sql-orm-cli)" >> "$GITHUB_OUTPUT"
 
+      - name: Delete all ephemeral ci.* versions from GitHub Packages
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci/github-packages.mjs cleanup-all-ci-versions
+
       - name: Summary
         run: |
           echo "## Weekly GitHub Packages (latest)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/weekly-gpr.yml
+++ b/.github/workflows/weekly-gpr.yml
@@ -1,0 +1,129 @@
+# Weekly snapshot of green master → GitHub Packages (dist-tag: latest).
+# Official semver releases stay on npmjs.com (manual).
+name: Weekly GitHub Packages (latest)
+
+on:
+  schedule:
+    # Sunday 02:00 UTC
+    - cron: "0 2 * * 0"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
+concurrency:
+  group: weekly-gpr
+  cancel-in-progress: false
+
+jobs:
+  weekly-latest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          fetch-depth: 1
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Verify master HEAD has a green CI run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci/github-packages.mjs verify-master-ci "${{ github.sha }}"
+
+      - name: Install core dependencies
+        run: npm ci --ignore-scripts
+
+      - name: REUSE / SPDX compliance
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5
+
+      - run: npm run knip
+
+      - name: License compliance (no GPL/LGPL/AGPL/copyleft)
+        run: npm run license:check
+
+      - run: npm run lint
+      - run: npm run build
+      - run: npm run format:check
+      - run: npm run test:coverage
+
+      - name: Set weekly version suffix
+        id: weekly
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          else
+            echo "date=$(date -u +%Y%m%d)-m${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish weekly forge-sql-orm to GitHub Packages (latest)
+        id: publish_weekly_core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEEKLY_BUILD_DATE: ${{ steps.weekly.outputs.date }}
+        run: |
+          node scripts/ci/github-packages.mjs publish-weekly-core
+          echo "core_version=$(node scripts/ci/github-packages.mjs weekly-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Extra package (quality gate)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEEKLY_BUILD_DATE: ${{ steps.weekly.outputs.date }}
+        run: |
+          cd forge-sql-orm-extra
+          npm ci --ignore-scripts
+          node ../scripts/ci/github-packages.mjs install-workspace . "${{ steps.publish_weekly_core.outputs.core_version }}"
+          npm run license:check
+          npm run knip
+          npm run build
+          npm run test:coverage
+
+      - name: Publish weekly forge-sql-orm-extra to GitHub Packages (latest)
+        id: publish_weekly_extra
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEEKLY_BUILD_DATE: ${{ steps.weekly.outputs.date }}
+        run: |
+          node scripts/ci/github-packages.mjs publish-weekly-extra "${{ steps.publish_weekly_core.outputs.core_version }}"
+          echo "extra_version=$(node scripts/ci/github-packages.mjs weekly-version forge-sql-orm-extra)" >> "$GITHUB_OUTPUT"
+
+      - name: CLI package (quality gate)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEEKLY_BUILD_DATE: ${{ steps.weekly.outputs.date }}
+        run: |
+          cd forge-sql-orm-cli
+          npm ci --ignore-scripts
+          node ../scripts/ci/github-packages.mjs install-workspace . "${{ steps.publish_weekly_core.outputs.core_version }}"
+          npm run knip
+          npm run lint
+          npm run build
+          npm run test:coverage
+
+      - name: Publish weekly forge-sql-orm-cli to GitHub Packages (latest)
+        id: publish_weekly_cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEEKLY_BUILD_DATE: ${{ steps.weekly.outputs.date }}
+        run: |
+          node scripts/ci/github-packages.mjs publish-weekly-cli "${{ steps.publish_weekly_core.outputs.core_version }}"
+          echo "cli_version=$(node scripts/ci/github-packages.mjs weekly-version forge-sql-orm-cli)" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          echo "## Weekly GitHub Packages (latest)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Version | dist-tag |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| forge-sql-orm | ${{ steps.publish_weekly_core.outputs.core_version }} | latest |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| forge-sql-orm-extra | ${{ steps.publish_weekly_extra.outputs.extra_version }} | latest |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| forge-sql-orm-cli | ${{ steps.publish_weekly_cli.outputs.cli_version }} | latest |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/github-packages.mjs
+++ b/scripts/ci/github-packages.mjs
@@ -7,7 +7,7 @@
  * publish uses a temporary directory with an adjusted manifest only for npm publish.
  */
 
-import { cleanupCiVersions } from "./gpr-delete.mjs";
+import { cleanupAllCiVersions, cleanupCiVersions } from "./gpr-delete.mjs";
 import {
   installExampleDeps,
   installWorkspacePackages,
@@ -22,7 +22,7 @@ import { ciVersion, weeklyVersion, writeNpmrc } from "./gpr-shared.mjs";
 import { verifyMasterCiGreen } from "./verify-master-ci.mjs";
 
 const COMMAND_USAGE =
-  "ci-version | weekly-version | write-npmrc | publish-core | publish-extra | publish-cli | publish-weekly-core | publish-weekly-extra | publish-weekly-cli | verify-master-ci | install-workspace | install-example | cleanup-ci-versions";
+  "ci-version | weekly-version | write-npmrc | publish-core | publish-extra | publish-cli | publish-weekly-core | publish-weekly-extra | publish-weekly-cli | verify-master-ci | install-workspace | install-example | cleanup-ci-versions | cleanup-all-ci-versions";
 
 function requireCliArg(args, index, usage) {
   const value = args[index];
@@ -115,6 +115,7 @@ const commandHandlers = {
   "install-workspace": runInstallWorkspaceCommand,
   "install-example": runInstallExampleCommand,
   "cleanup-ci-versions": cleanupCiVersions,
+  "cleanup-all-ci-versions": cleanupAllCiVersions,
 };
 
 async function main() {

--- a/scripts/ci/github-packages.mjs
+++ b/scripts/ci/github-packages.mjs
@@ -14,11 +14,15 @@ import {
   publishCli,
   publishCore,
   publishExtra,
+  publishWeeklyCli,
+  publishWeeklyCore,
+  publishWeeklyExtra,
 } from "./gpr-publish.mjs";
-import { ciVersion, writeNpmrc } from "./gpr-shared.mjs";
+import { ciVersion, weeklyVersion, writeNpmrc } from "./gpr-shared.mjs";
+import { verifyMasterCiGreen } from "./verify-master-ci.mjs";
 
 const COMMAND_USAGE =
-  "ci-version | write-npmrc | publish-core | publish-extra | publish-cli | install-workspace | install-example | cleanup-ci-versions";
+  "ci-version | weekly-version | write-npmrc | publish-core | publish-extra | publish-cli | publish-weekly-core | publish-weekly-extra | publish-weekly-cli | verify-master-ci | install-workspace | install-example | cleanup-ci-versions";
 
 function requireCliArg(args, index, usage) {
   const value = args[index];
@@ -30,6 +34,10 @@ function requireCliArg(args, index, usage) {
 
 function runCiVersionCommand(args) {
   console.log(ciVersion(args[0] ?? "."));
+}
+
+function runWeeklyVersionCommand(args) {
+  console.log(weeklyVersion(args[0] ?? "."));
 }
 
 function runWriteNpmrcCommand() {
@@ -49,6 +57,25 @@ async function runPublishExtraCommand(args) {
 async function runPublishCliCommand(args) {
   writeNpmrc();
   await publishCli(requireCliArg(args, 0, "publish-cli <coreVersion>"));
+}
+
+async function runPublishWeeklyCoreCommand() {
+  writeNpmrc();
+  await publishWeeklyCore();
+}
+
+async function runPublishWeeklyExtraCommand(args) {
+  writeNpmrc();
+  await publishWeeklyExtra(requireCliArg(args, 0, "publish-weekly-extra <coreVersion>"));
+}
+
+async function runPublishWeeklyCliCommand(args) {
+  writeNpmrc();
+  await publishWeeklyCli(requireCliArg(args, 0, "publish-weekly-cli <coreVersion>"));
+}
+
+async function runVerifyMasterCiCommand(args) {
+  await verifyMasterCiGreen(requireCliArg(args, 0, "verify-master-ci <headSha>"));
 }
 
 function runInstallWorkspaceCommand(args) {
@@ -76,10 +103,15 @@ function runInstallExampleCommand(args) {
 
 const commandHandlers = {
   "ci-version": runCiVersionCommand,
+  "weekly-version": runWeeklyVersionCommand,
   "write-npmrc": runWriteNpmrcCommand,
   "publish-core": runPublishCoreCommand,
   "publish-extra": runPublishExtraCommand,
   "publish-cli": runPublishCliCommand,
+  "publish-weekly-core": runPublishWeeklyCoreCommand,
+  "publish-weekly-extra": runPublishWeeklyExtraCommand,
+  "publish-weekly-cli": runPublishWeeklyCliCommand,
+  "verify-master-ci": runVerifyMasterCiCommand,
   "install-workspace": runInstallWorkspaceCommand,
   "install-example": runInstallExampleCommand,
   "cleanup-ci-versions": cleanupCiVersions,

--- a/scripts/ci/gpr-delete.mjs
+++ b/scripts/ci/gpr-delete.mjs
@@ -12,6 +12,12 @@ import {
 } from "./gpr-shared.mjs";
 
 const MAX_VERSION_PAGES = 5;
+const MAX_CLEANUP_VERSION_PAGES = 50;
+const CI_VERSION_PATTERN = /-ci\.\d+(?:-a\d+)?$/;
+
+function isCiEphemeralVersion(versionName) {
+  return CI_VERSION_PATTERN.test(versionName);
+}
 
 function matchesPackageName(pkgName, unscopedName) {
   const owner = githubOwner();
@@ -95,6 +101,17 @@ async function findPackageApiName(owner, unscopedName, token) {
   return null;
 }
 
+async function deleteVersionById(root, versionId, scopedName, versionName, token) {
+  const response = await githubApi(`${root}/versions/${versionId}`, { method: "DELETE", token });
+  if (response.status === 204) {
+    console.error(`Deleted ${scopedName}@${versionName}`);
+    return;
+  }
+
+  const body = await response.text();
+  console.warn(`Failed to delete ${scopedName}@${versionName}: ${response.status} ${body}`);
+}
+
 async function deleteLocatedVersion(located, version, scopedName, token) {
   const match = located.versions.find((entry) => entry.name === version);
   if (!match) {
@@ -102,14 +119,52 @@ async function deleteLocatedVersion(located, version, scopedName, token) {
     return;
   }
 
-  const response = await githubApi(`${located.root}/versions/${match.id}`, { method: "DELETE", token });
-  if (response.status === 204) {
-    console.error(`Deleted ${scopedName}@${version}`);
+  await deleteVersionById(located.root, match.id, scopedName, version, token);
+}
+
+async function collectAllVersionsForRoot(root, token, apiPackageName) {
+  const versions = [];
+  for (let page = 1; page <= MAX_CLEANUP_VERSION_PAGES; page += 1) {
+    const pageResult = await readVersionsPage(root, page, token, apiPackageName);
+    versions.push(...pageResult.versions);
+    if (pageResult.stop) {
+      break;
+    }
+  }
+  return versions;
+}
+
+async function listAllPackageVersions(owner, apiPackageName, token) {
+  for (const root of packageVersionRoots(owner, apiPackageName)) {
+    const versions = await collectAllVersionsForRoot(root, token, apiPackageName);
+    if (versions.length) {
+      return { root, versions };
+    }
+  }
+  return null;
+}
+
+async function cleanupAllCiVersionsForPackage(unscopedName) {
+  const owner = githubOwner();
+  const token = githubToken();
+  const scopedName = scopedGprName(unscopedName);
+  const apiPackageName = await findPackageApiName(owner, unscopedName, token);
+  if (!apiPackageName) {
+    console.error(`Package ${scopedName} not found in GitHub Packages API, skipping ci cleanup`);
     return;
   }
 
-  const body = await response.text();
-  console.warn(`Failed to delete ${scopedName}@${version}: ${response.status} ${body}`);
+  const located = await listAllPackageVersions(owner, apiPackageName, token);
+  if (!located) {
+    console.error(`No versions listed for ${apiPackageName}, skipping ci cleanup`);
+    return;
+  }
+
+  const ciVersions = located.versions.filter((entry) => isCiEphemeralVersion(entry.name));
+  console.error(`Deleting ${ciVersions.length} ci.* version(s) for ${scopedName}`);
+  for (const entry of ciVersions) {
+    await deleteVersionById(located.root, entry.id, scopedName, entry.name, token);
+  }
 }
 
 async function deleteGprVersion(unscopedName, version) {
@@ -135,5 +190,12 @@ export async function cleanupCiVersions() {
   for (const dir of CI_PACKAGE_DIRS) {
     const pkg = readPkg(dir);
     await deleteGprVersion(pkg.name, ciVersion(dir));
+  }
+}
+
+export async function cleanupAllCiVersions() {
+  for (const dir of CI_PACKAGE_DIRS) {
+    const pkg = readPkg(dir);
+    await cleanupAllCiVersionsForPackage(pkg.name);
   }
 }

--- a/scripts/ci/gpr-publish.mjs
+++ b/scripts/ci/gpr-publish.mjs
@@ -8,12 +8,14 @@ import { tmpdir } from "node:os";
 import {
   CI_PUBLISH_TAG,
   GPR_REGISTRY,
+  LATEST_PUBLISH_TAG,
   ciVersion,
   gprDependencyAlias,
   gprInstallAlias,
   npmEnvWithoutUserConfig,
   readPkg,
   scopedGprName,
+  weeklyVersion,
   writeNpmrc,
 } from "./gpr-shared.mjs";
 
@@ -57,7 +59,8 @@ function sanitizePublishManifest(pkg) {
   delete pkg.devDependencies;
 }
 
-async function npmPublishEphemeral(sourceDir, version, transformPkg) {
+async function npmPublishEphemeral(sourceDir, version, options = {}) {
+  const { transformPkg, publishTag = CI_PUBLISH_TAG } = options;
   const sourcePkg = readPkg(sourceDir);
   const publishPkg = structuredClone(sourcePkg);
   publishPkg.name = scopedGprName(sourcePkg.name);
@@ -72,8 +75,8 @@ async function npmPublishEphemeral(sourceDir, version, transformPkg) {
     writeFileSync(`${stagingDir}/package.json`, `${JSON.stringify(publishPkg, null, 2)}\n`);
     writeNpmrc(stagingDir);
     try {
-      runNpmCommand(stagingDir, `publish --ignore-scripts --tag ${CI_PUBLISH_TAG}`);
-      console.error(`Published ${publishPkg.name}@${version} to GitHub Packages`);
+      runNpmCommand(stagingDir, `publish --ignore-scripts --tag ${publishTag}`);
+      console.error(`Published ${publishPkg.name}@${version} (${publishTag}) to GitHub Packages`);
     } catch (error) {
       if (isGprAlreadyPublishedError(error)) {
         console.error(`Already published ${publishPkg.name}@${version}, continuing`);
@@ -102,6 +105,12 @@ function hasDep(pkg, name) {
   return Boolean(pkg.dependencies?.[name] ?? pkg.devDependencies?.[name]);
 }
 
+function linkCoreDependency(pkg, coreVersion) {
+  if (pkg.dependencies?.["forge-sql-orm"]) {
+    pkg.dependencies["forge-sql-orm"] = gprDependencyAlias("forge-sql-orm", coreVersion);
+  }
+}
+
 export async function publishCore() {
   const version = ciVersion(".");
   await npmPublishEphemeral(".", version);
@@ -109,19 +118,36 @@ export async function publishCore() {
 
 export async function publishExtra(coreVersion) {
   const version = ciVersion("forge-sql-orm-extra");
-  await npmPublishEphemeral("forge-sql-orm-extra", version, (pkg) => {
-    if (pkg.dependencies?.["forge-sql-orm"]) {
-      pkg.dependencies["forge-sql-orm"] = gprDependencyAlias("forge-sql-orm", coreVersion);
-    }
+  await npmPublishEphemeral("forge-sql-orm-extra", version, {
+    transformPkg: (pkg) => linkCoreDependency(pkg, coreVersion),
   });
 }
 
 export async function publishCli(coreVersion) {
   const version = ciVersion("forge-sql-orm-cli");
-  await npmPublishEphemeral("forge-sql-orm-cli", version, (pkg) => {
-    if (pkg.dependencies?.["forge-sql-orm"]) {
-      pkg.dependencies["forge-sql-orm"] = gprDependencyAlias("forge-sql-orm", coreVersion);
-    }
+  await npmPublishEphemeral("forge-sql-orm-cli", version, {
+    transformPkg: (pkg) => linkCoreDependency(pkg, coreVersion),
+  });
+}
+
+export async function publishWeeklyCore() {
+  const version = weeklyVersion(".");
+  await npmPublishEphemeral(".", version, { publishTag: LATEST_PUBLISH_TAG });
+}
+
+export async function publishWeeklyExtra(coreVersion) {
+  const version = weeklyVersion("forge-sql-orm-extra");
+  await npmPublishEphemeral("forge-sql-orm-extra", version, {
+    publishTag: LATEST_PUBLISH_TAG,
+    transformPkg: (pkg) => linkCoreDependency(pkg, coreVersion),
+  });
+}
+
+export async function publishWeeklyCli(coreVersion) {
+  const version = weeklyVersion("forge-sql-orm-cli");
+  await npmPublishEphemeral("forge-sql-orm-cli", version, {
+    publishTag: LATEST_PUBLISH_TAG,
+    transformPkg: (pkg) => linkCoreDependency(pkg, coreVersion),
   });
 }
 

--- a/scripts/ci/gpr-shared.mjs
+++ b/scripts/ci/gpr-shared.mjs
@@ -6,7 +6,9 @@ import path from "node:path";
 
 export const GPR_REGISTRY = "https://npm.pkg.github.com";
 export const CI_PUBLISH_TAG = "ci";
+export const LATEST_PUBLISH_TAG = "latest";
 export const CI_PACKAGE_DIRS = [".", "forge-sql-orm-extra", "forge-sql-orm-cli"];
+export const WEEKLY_WORKFLOW_FILE = "node.js.yml";
 
 function requireRunNumber() {
   const runNumber = process.env.GITHUB_RUN_NUMBER;
@@ -21,7 +23,22 @@ export function readPkg(dir) {
 }
 
 function baseVersion(version) {
-  return String(version).replace(/-ci\.[\d]+(?:-a[\d]+)?$/, "");
+  return String(version)
+    .replace(/-ci\.[\d]+(?:-a[\d]+)?$/, "")
+    .replace(/-weekly\.\d{8}$/, "");
+}
+
+export function weeklyVersionLabel() {
+  const fromEnv = process.env.WEEKLY_BUILD_DATE;
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return new Date().toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+export function weeklyVersion(dir = ".") {
+  const pkg = readPkg(dir);
+  return `${baseVersion(pkg.version)}-weekly.${weeklyVersionLabel()}`;
 }
 
 function ciVersionLabel() {

--- a/scripts/ci/verify-master-ci.mjs
+++ b/scripts/ci/verify-master-ci.mjs
@@ -11,14 +11,6 @@ function requireRepository() {
   return repository;
 }
 
-function requireHeadSha(args) {
-  const headSha = args[0] ?? process.env.GITHUB_SHA;
-  if (!headSha) {
-    throw new Error("usage: verify-master-ci <headSha>");
-  }
-  return headSha;
-}
-
 function isGreenMasterRun(run) {
   return run.conclusion === "success" && run.event === "push";
 }

--- a/scripts/ci/verify-master-ci.mjs
+++ b/scripts/ci/verify-master-ci.mjs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 Vasyl Zakharchenko
+// SPDX-License-Identifier: MIT
+
+import { githubApi, WEEKLY_WORKFLOW_FILE } from "./gpr-shared.mjs";
+
+function requireRepository() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY is required to verify CI status");
+  }
+  return repository;
+}
+
+function requireHeadSha(args) {
+  const headSha = args[0] ?? process.env.GITHUB_SHA;
+  if (!headSha) {
+    throw new Error("usage: verify-master-ci <headSha>");
+  }
+  return headSha;
+}
+
+function isGreenMasterRun(run) {
+  return run.conclusion === "success" && run.event === "push";
+}
+
+export async function verifyMasterCiGreen(headSha) {
+  const repository = requireRepository();
+  const response = await githubApi(
+    `/repos/${repository}/actions/workflows/${WEEKLY_WORKFLOW_FILE}/runs?head_sha=${headSha}&status=completed&per_page=20`,
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to query workflow runs (${response.status}): ${body}`);
+  }
+
+  const payload = await response.json();
+  const greenRun = payload.workflow_runs?.find(isGreenMasterRun);
+  if (!greenRun) {
+    throw new Error(
+      `master @ ${headSha} is not green: no successful push run of ${WEEKLY_WORKFLOW_FILE} found`,
+    );
+  }
+
+  console.error(
+    `Verified green master CI: workflow run ${greenRun.id} (${greenRun.html_url}) for ${headSha}`,
+  );
+  return greenRun;
+}
+


### PR DESCRIPTION

- Refactored CI scripts for better modularity and tag-specific publishing options.

# Description
add weekly GPR publishing workflow and versioning logic 
- Introduced `weekly-gpr.yml` to publish weekly snapshots of all packages to GitHub Packages with the `latest` dist-tag.
- Added `weeklyVersion` logic and helper functions to generate version labels based on build dates.
- Extended publishing scripts to support weekly releases for `forge-sql-orm`, `forge-sql-orm-extra`, and `forge-sql-orm-cli`.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated weekly publishing to GitHub Packages for core, extra, and CLI packages under the "latest" tag, with optional manual trigger.
  * Releases use a computed weekly version suffix (YYYYMMDD with a manual-run marker) and produce a workflow summary listing package versions and commit SHAs.
  * Workflow enforces CI verification and quality gates before publishing (install/license/knip/lint/build/tests/coverage).
  * Removes ephemeral CI-tagged package versions after publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->