### PR TITLE
chore: bump to version 2.2.0 and update optional dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ preserved verbatim. The project follows [Semantic Versioning](https://semver.org
 
 > See also: [GitHub Releases](https://github.com/forge-sql-orm/forge-sql-orm/releases).
 
-## [2.2.0] - IN PROGRESS
+## [2.2.0] - 2026-06-06
 
 🚀 What's New
 

--- a/autoupdate.sh
+++ b/autoupdate.sh
@@ -21,7 +21,7 @@ run() { echo -e "${YELLOW}  →${RESET} $*"; "$@"; }
 
 section "Root package (forge-sql-orm)"
 step "Updating dependencies (ncu -u)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Removing node_modules and package-lock.json..."
 run rm -rf node_modules package-lock.json
 step "Installing dependencies (npm i)..."
@@ -38,7 +38,7 @@ run git add package.json package-lock.json
 section "forge-sql-orm-cli"
 step "Updating dependencies (ncu -u)..."
 cd forge-sql-orm-cli
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Removing node_modules and package-lock.json..."
 run rm -rf node_modules package-lock.json
 step "Installing dependencies (npm i)..."
@@ -54,7 +54,7 @@ run npm run build
 section "forge-sql-orm-extra"
 step "Updating dependencies (ncu -u)..."
 cd forge-sql-orm-extra
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Removing node_modules and package-lock.json..."
 run rm -rf node_modules package-lock.json
 step "Installing dependencies (npm i)..."
@@ -72,7 +72,7 @@ cd forge-sql-orm-example-drizzle-driver-simple
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -82,7 +82,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -98,7 +98,7 @@ cd forge-sql-orm-example-dynamic
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -108,7 +108,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -124,7 +124,7 @@ cd forge-sql-orm-example-optimistic-locking
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -134,7 +134,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -150,7 +150,7 @@ cd forge-sql-orm-example-query-analyses
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -160,7 +160,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -176,7 +176,7 @@ cd forge-sql-orm-example-simple
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -186,7 +186,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -202,7 +202,7 @@ cd forge-sql-orm-example-checklist
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -212,7 +212,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -228,7 +228,7 @@ cd forge-sql-orm-example-org-tracker
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -238,7 +238,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -254,7 +254,7 @@ cd forge-sql-orm-example-sql-executor
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -264,7 +264,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -280,7 +280,7 @@ cd forge-sql-orm-example-cache
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -290,7 +290,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -307,7 +307,7 @@ cd forge-sql-orm-example-atlascamp
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -317,7 +317,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -333,7 +333,7 @@ cd forge-sql-orm-example-vector
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -343,7 +343,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -359,7 +359,7 @@ cd forge-sql-orm-example-ai
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -369,7 +369,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -385,7 +385,7 @@ cd forge-sql-orm-example-backend-ai
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."
@@ -395,7 +395,7 @@ run git add package.json package-lock.json
 step "Static UI: removing and updating deps..."
 cd ai-lib
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "AI-LIB: installing..."
 run npm i
 step "AI-LIB: building..."
@@ -405,7 +405,7 @@ sleep 2
 run git add package.json package-lock.json
 cd ../static/forge-orm-example
 run rm -rf node_modules package-lock.json
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 run rm -rf package-lock.json
 step "Static UI: installing and knip..."
 run npm i
@@ -421,7 +421,7 @@ cd forge-sql-orm-example-ui-kit
 step "Removing node_modules and lock file..."
 run rm -rf node_modules package-lock.json
 step "Updating dependencies (ncu)..."
-run ncu -u --dep prod,dev,peer
+run ncu -u --dep prod,dev,peer,optional
 step "Installing dependencies..."
 run npm i
 step "Running knip..."

--- a/examples/forge-sql-orm-example-ai/package-lock.json
+++ b/examples/forge-sql-orm-example-ai/package-lock.json
@@ -12,7 +12,7 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29"
+        "forge-sql-orm": "^2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
@@ -100,16 +100,6 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
       }
     },
     "node_modules/@forge/manifest": {
@@ -296,9 +286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -316,9 +303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,9 +320,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,9 +337,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -376,9 +354,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,9 +371,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,9 +388,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -436,9 +405,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,9 +617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,9 +631,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,9 +645,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,9 +659,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,9 +673,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,9 +687,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,9 +701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +715,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,13 +866,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -971,16 +906,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1327,21 +1252,19 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -1562,20 +1485,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {

--- a/examples/forge-sql-orm-example-ai/package.json
+++ b/examples/forge-sql-orm-example-ai/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29"
+    "forge-sql-orm": "^2.2.0"
   },
   "scripts": {
     "build:ci": "tsc --target esnext --project tsconfig.json --ignoreDeprecations 6.0 --outDir dist && rm -rf dist",

--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
@@ -1232,9 +1232,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1250,9 +1247,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1270,9 +1264,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1288,9 +1279,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1308,9 +1296,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1326,9 +1311,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1346,9 +1328,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1365,9 +1344,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1383,9 +1359,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1409,9 +1382,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1433,9 +1403,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1459,9 +1426,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1483,9 +1447,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1509,9 +1470,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1534,9 +1492,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1558,9 +1513,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1913,9 +1865,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,9 +1882,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,9 +1899,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,9 +1916,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,9 +1933,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,9 +1950,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2033,9 +1967,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,9 +1984,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2268,9 +2196,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,9 +2224,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2319,9 +2238,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,9 +2252,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,9 +2266,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,9 +2280,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,9 +2294,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2623,9 +2527,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,9 +2544,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2663,9 +2561,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2683,9 +2578,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,9 +2595,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2612,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4265,9 +4151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4289,9 +4172,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4313,9 +4193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4337,9 +4214,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-atlascamp/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/package-lock.json
@@ -14,12 +14,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.2.0",
-        "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
+        "forge-sql-orm": "2.1.29",
+        "forge-sql-orm-extra": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.2.0",
+        "forge-sql-orm-cli": "^2.1.29",
         "knip": "^6.16.0",
         "mysql2": "^3.22.4",
         "typescript": "^6.0.3"
@@ -1732,6 +1732,13 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/pegjs": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
+      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1782,6 +1789,16 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -2270,19 +2287,21 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
-      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
+      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.1",
+        "@forge/api": "^7.2.0",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.6"
+        "@forge/events": "^2.1.4",
+        "@forge/kvs": "^1.6.2",
+        "node-sql-parser": "^5.4.0"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.25",
+        "@forge/sql": "^3.0.24",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -2305,6 +2324,24 @@
       },
       "bin": {
         "forge-sql-orm-cli": "dist-cli/forgeSqlOrmCLI.js"
+      }
+    },
+    "node_modules/forge-sql-orm-cli/node_modules/forge-sql-orm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@forge/api": "^7.2.1",
+        "luxon": "^3.7.2"
+      },
+      "optionalDependencies": {
+        "@forge/events": "^2.1.6"
+      },
+      "peerDependencies": {
+        "@forge/sql": "^3.0.25",
+        "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-extra": {
@@ -2672,6 +2709,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/node-sql-parser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
+      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@types/pegjs": "^0.10.0",
+        "big-integer": "^1.6.48"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nth-check": {

--- a/examples/forge-sql-orm-example-atlascamp/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/package-lock.json
@@ -14,12 +14,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29",
+        "forge-sql-orm": "2.2.0",
         "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "mysql2": "^3.22.4",
         "typescript": "^6.0.3"
@@ -31,7 +31,7 @@
       "dependencies": {
         "@forge/kvs": "^1.6.4",
         "@forge/sql": "^3.0.25",
-        "forge-sql-orm": "file:..",
+        "forge-sql-orm": "^2.2.0",
         "luxon": "^3.7.2",
         "node-sql-parser": "^5.4.0"
       },
@@ -1152,9 +1152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,9 +1169,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1186,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1203,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,9 +1220,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1237,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1254,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,9 +1271,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,9 +1483,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1524,9 +1497,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1541,9 +1511,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1558,9 +1525,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1575,9 +1539,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1592,9 +1553,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1780,13 +1732,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1837,16 +1782,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1934,13 +1869,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2335,38 +2270,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2499,22 +2432,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2742,20 +2674,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2949,16 +2867,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-atlascamp/package.json
+++ b/examples/forge-sql-orm-example-atlascamp/package.json
@@ -11,7 +11,7 @@
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
     "forge-sql-orm": "2.1.29",
-    "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
+    "forge-sql-orm-extra": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",

--- a/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package-lock.json
@@ -680,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +731,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1039,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1067,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1081,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1303,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1320,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2671,9 +2602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2695,9 +2623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2719,9 +2644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-backend-ai/ai-lib/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/ai-lib/package-lock.json
@@ -613,9 +613,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -631,9 +628,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -651,9 +645,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -669,9 +660,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -689,9 +677,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -707,9 +692,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -727,9 +709,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -746,9 +725,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -764,9 +740,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -790,9 +763,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -814,9 +784,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -840,9 +807,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -864,9 +828,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -890,9 +851,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -915,9 +873,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -939,9 +894,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1257,9 +1209,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,9 +1226,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,9 +1243,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1260,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1277,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1294,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2209,9 +2143,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2233,9 +2164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2257,9 +2185,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2281,9 +2206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-backend-ai/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/package-lock.json
@@ -12,7 +12,7 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29"
+        "forge-sql-orm": "^2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
@@ -100,16 +100,6 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
       }
     },
     "node_modules/@forge/manifest": {
@@ -296,9 +286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -316,9 +303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,9 +320,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,9 +337,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -376,9 +354,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,9 +371,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,9 +388,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -436,9 +405,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,9 +617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,9 +631,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,9 +645,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,9 +659,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,9 +673,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,9 +687,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,9 +701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +715,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,13 +866,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -971,16 +906,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1327,21 +1252,19 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -1562,20 +1485,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {

--- a/examples/forge-sql-orm-example-backend-ai/package.json
+++ b/examples/forge-sql-orm-example-backend-ai/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29"
+    "forge-sql-orm": "^2.2.0"
   },
   "scripts": {
     "build:ci": "tsc --target esnext --project tsconfig.json --ignoreDeprecations 6.0 --outDir dist && rm -rf dist",

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
@@ -1371,9 +1371,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1391,9 +1388,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1411,9 +1405,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1431,9 +1422,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1451,9 +1439,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1471,9 +1456,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1491,9 +1473,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1511,9 +1490,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1702,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1743,9 +1716,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,9 +1730,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1777,9 +1744,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1794,9 +1758,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1811,9 +1772,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1828,9 +1786,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1845,9 +1800,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,9 +1970,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +1987,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,9 +2004,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,9 +2021,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,9 +2038,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,9 +2055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3516,9 +3450,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3540,9 +3471,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3564,9 +3492,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3588,9 +3513,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-cache/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/package-lock.json
@@ -15,12 +15,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
+        "forge-sql-orm": "^2.2.0",
         "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -31,7 +31,7 @@
       "dependencies": {
         "@forge/kvs": "^1.6.4",
         "@forge/sql": "^3.0.25",
-        "forge-sql-orm": "file:..",
+        "forge-sql-orm": "^2.2.0",
         "luxon": "^3.7.2",
         "node-sql-parser": "^5.4.0"
       },
@@ -1152,9 +1152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,9 +1169,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1186,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1203,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,9 +1220,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1237,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1254,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,9 +1271,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,9 +1483,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1524,9 +1497,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1541,9 +1511,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1558,9 +1525,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1575,9 +1539,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1592,9 +1553,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1780,13 +1732,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1837,16 +1782,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1934,13 +1869,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2335,38 +2270,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2499,22 +2432,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2742,20 +2674,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2949,16 +2867,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-cache/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/package-lock.json
@@ -16,7 +16,7 @@
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
         "forge-sql-orm": "^2.2.0",
-        "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
+        "forge-sql-orm-extra": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",

--- a/examples/forge-sql-orm-example-cache/package.json
+++ b/examples/forge-sql-orm-example-cache/package.json
@@ -11,8 +11,8 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29",
-    "forge-sql-orm-extra": "file:../../forge-sql-orm-extra"
+    "forge-sql-orm": "^2.2.0",
+    "forge-sql-orm-extra": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-cache/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/static/forge-orm-example/package-lock.json
@@ -680,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +731,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1039,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1067,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1081,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1303,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1320,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2671,9 +2602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2695,9 +2623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2719,9 +2644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-checklist/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/package-lock.json
@@ -13,11 +13,11 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29"
+        "forge-sql-orm": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -577,16 +577,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1132,9 +1122,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,9 +1139,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,9 +1156,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1173,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1190,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,9 +1207,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1241,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,9 +1453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,9 +1467,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,9 +1481,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,9 +1495,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,9 +1509,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,9 +1523,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,9 +1537,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,9 +1551,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,13 +1702,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1817,16 +1752,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1914,13 +1839,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2315,38 +2240,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2475,22 +2398,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2718,20 +2640,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2925,16 +2833,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-checklist/package.json
+++ b/examples/forge-sql-orm-example-checklist/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "2.1.29"
+    "forge-sql-orm": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package-lock.json
@@ -680,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +731,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1039,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1067,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1081,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1303,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1320,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2671,9 +2602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2695,9 +2623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2719,9 +2644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
@@ -12,12 +12,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29"
+        "forge-sql-orm": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
         "drizzle-kit": "^0.31.10",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "mysql2": "^3.22.4",
         "typescript": "^6.0.3"
@@ -578,16 +578,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1133,9 +1123,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,9 +1140,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1173,9 +1157,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,9 +1174,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1213,9 +1191,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,9 +1208,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1253,9 +1225,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,9 +1242,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1488,9 +1454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1505,9 +1468,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1522,9 +1482,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1539,9 +1496,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1556,9 +1510,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1573,9 +1524,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,9 +1538,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1607,9 +1552,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1761,13 +1703,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1818,16 +1753,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1915,13 +1840,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2316,38 +2241,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2476,22 +2399,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2719,20 +2641,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2926,16 +2834,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
@@ -7,12 +7,12 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "2.1.29"
+    "forge-sql-orm": "2.2.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
     "drizzle-kit": "^0.31.10",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "mysql2": "^3.22.4",
     "typescript": "^6.0.3"

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
@@ -1264,9 +1264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1281,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1304,9 +1298,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,9 +1315,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1332,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1349,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1366,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1383,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1619,9 +1595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1636,9 +1609,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,9 +1623,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1637,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1651,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1665,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1721,9 +1679,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1738,9 +1693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,9 +1863,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1931,9 +1880,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,9 +1897,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1971,9 +1914,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,9 +1931,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1948,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3409,9 +3343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3433,9 +3364,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3457,9 +3385,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3481,9 +3406,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-dynamic/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/package-lock.json
@@ -12,11 +12,11 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29"
+        "forge-sql-orm": "^2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -576,16 +576,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1131,9 +1121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1155,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1486,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1503,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1520,9 +1480,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1537,9 +1494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1508,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,9 +1536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1605,9 +1550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,13 +1701,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1816,16 +1751,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1913,13 +1838,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2314,38 +2239,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2474,22 +2397,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2717,20 +2639,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2924,16 +2832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-dynamic/package.json
+++ b/examples/forge-sql-orm-example-dynamic/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29"
+    "forge-sql-orm": "^2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
@@ -1264,9 +1264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1281,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1304,9 +1298,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,9 +1315,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1332,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1349,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1366,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1383,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1619,9 +1595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1636,9 +1609,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,9 +1623,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1637,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1651,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1665,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1721,9 +1679,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1738,9 +1693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,9 +1863,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1931,9 +1880,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,9 +1897,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1971,9 +1914,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,9 +1931,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1948,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3409,9 +3343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3433,9 +3364,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3457,9 +3385,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3481,9 +3406,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
@@ -12,11 +12,11 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29"
+        "forge-sql-orm": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -576,16 +576,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1131,9 +1121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1155,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1486,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1503,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1520,9 +1480,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1537,9 +1494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1508,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,9 +1536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1605,9 +1550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,13 +1701,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1816,16 +1751,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1913,13 +1838,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2314,38 +2239,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2474,22 +2397,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2717,20 +2639,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2924,16 +2832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-optimistic-locking/package.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/package.json
@@ -7,7 +7,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "2.1.29"
+    "forge-sql-orm": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
@@ -1284,9 +1284,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1304,9 +1301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,9 +1318,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1335,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1352,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1369,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1403,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1639,9 +1615,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1656,9 +1629,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1673,9 +1643,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1690,9 +1657,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1671,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,9 +1685,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1741,9 +1699,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1758,9 +1713,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1931,9 +1883,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,9 +1900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1971,9 +1917,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,9 +1934,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1951,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,9 +1968,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3429,9 +3363,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3453,9 +3384,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3477,9 +3405,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3501,9 +3426,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-org-tracker/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/package-lock.json
@@ -12,11 +12,11 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29"
+        "forge-sql-orm": "^2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -576,16 +576,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1131,9 +1121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1155,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1486,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1503,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1520,9 +1480,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1537,9 +1494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1508,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,9 +1536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1605,9 +1550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,13 +1701,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1816,16 +1751,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1913,13 +1838,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2314,38 +2239,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2474,22 +2397,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2717,20 +2639,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2924,16 +2832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-org-tracker/package.json
+++ b/examples/forge-sql-orm-example-org-tracker/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29"
+    "forge-sql-orm": "^2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package-lock.json
@@ -680,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +731,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1039,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1067,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1081,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1303,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1320,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2671,9 +2602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2695,9 +2623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2719,9 +2644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-query-analyses/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/package-lock.json
@@ -13,12 +13,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29",
+        "forge-sql-orm": "2.2.0",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -577,16 +577,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1132,9 +1122,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,9 +1139,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,9 +1156,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1173,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1190,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,9 +1207,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1241,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,9 +1453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,9 +1467,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,9 +1481,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,9 +1495,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,9 +1509,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,9 +1523,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,9 +1537,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,9 +1551,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,13 +1702,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1817,16 +1752,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1914,13 +1839,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2315,38 +2240,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2475,22 +2398,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2718,20 +2640,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2925,16 +2833,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-query-analyses/package.json
+++ b/examples/forge-sql-orm-example-query-analyses/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "2.1.29",
+    "forge-sql-orm": "2.2.0",
     "uuid": "^14.0.0"
   },
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
@@ -11,7 +11,7 @@
         "@atlaskit/css-reset": "^7.4.5",
         "@atlaskit/dynamic-table": "^18.4.2",
         "@forge/bridge": "^5.16.2",
-        "forge-sql-orm": "^2.1.29",
+        "forge-sql-orm": "^2.2.0",
         "mobx": "6.16.0",
         "mobx-react": "9.2.2",
         "react": "^18.3.1",
@@ -1015,16 +1015,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1324,9 +1314,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1331,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1348,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1365,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1382,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1399,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1444,9 +1416,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1464,9 +1433,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1679,9 +1645,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1696,9 +1659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1713,9 +1673,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1730,9 +1687,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1701,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1764,9 +1715,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,9 +1729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1798,9 +1743,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1971,9 +1913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,9 +1930,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1947,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,9 +1964,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,9 +1981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2071,9 +1998,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2344,13 +2268,6 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2506,16 +2423,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/bind-event-listener": {
@@ -3092,21 +2999,19 @@
       "license": "MIT"
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -3637,9 +3542,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3661,9 +3563,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3685,9 +3584,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3709,9 +3605,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4010,20 +3903,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
@@ -6,7 +6,7 @@
     "@atlaskit/css-reset": "^7.4.5",
     "@atlaskit/dynamic-table": "^18.4.2",
     "@forge/bridge": "^5.16.2",
-    "forge-sql-orm": "^2.1.29",
+    "forge-sql-orm": "^2.2.0",
     "mobx": "6.16.0",
     "mobx-react": "9.2.2",
     "react": "^18.3.1",

--- a/examples/forge-sql-orm-example-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/package-lock.json
@@ -12,11 +12,11 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "2.1.29"
+        "forge-sql-orm": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -576,16 +576,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1131,9 +1121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1155,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1486,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1503,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1520,9 +1480,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1537,9 +1494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1508,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,9 +1536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1605,9 +1550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,13 +1701,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1816,16 +1751,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1913,13 +1838,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2314,38 +2239,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2474,22 +2397,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2717,20 +2639,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2924,16 +2832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-simple/package.json
+++ b/examples/forge-sql-orm-example-simple/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "2.1.29"
+    "forge-sql-orm": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
@@ -1263,9 +1263,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1283,9 +1280,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,9 +1297,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,9 +1314,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,9 +1331,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +1348,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,9 +1365,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1403,9 +1382,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1618,9 +1594,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1635,9 +1608,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1652,9 +1622,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1669,9 +1636,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1686,9 +1650,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1703,9 +1664,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1720,9 +1678,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,9 +1692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1910,9 +1862,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1930,9 +1879,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1896,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,9 +1913,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1990,9 +1930,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,9 +1947,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3398,9 +3332,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3422,9 +3353,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3446,9 +3374,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3470,9 +3395,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-sql-executor/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/package-lock.json
@@ -11,11 +11,11 @@
       "dependencies": {
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
-        "forge-sql-orm": "2.1.29"
+        "forge-sql-orm": "2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0",
         "typescript": "^6.0.3"
       }
@@ -575,16 +575,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1130,9 +1120,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,9 +1137,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,9 +1154,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,9 +1171,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1188,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,9 +1205,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,9 +1239,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1485,9 +1451,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1502,9 +1465,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1519,9 +1479,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1536,9 +1493,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1553,9 +1507,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,9 +1521,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1587,9 +1535,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1604,9 +1549,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1758,13 +1700,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1815,16 +1750,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1912,13 +1837,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/css-select": {
@@ -2313,38 +2238,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -2473,22 +2396,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2716,20 +2638,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2923,16 +2831,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-sql-executor/package.json
+++ b/examples/forge-sql-orm-example-sql-executor/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
-    "forge-sql-orm": "2.1.29"
+    "forge-sql-orm": "2.2.0"
   },
   "scripts": {
     "models:create": "forge-sql-orm-cli generate:model --output src/entities",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0",
     "typescript": "^6.0.3"
   },

--- a/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package-lock.json
@@ -680,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +731,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1039,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1067,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1081,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1303,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1320,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2671,9 +2602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2695,9 +2623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2719,9 +2644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/examples/forge-sql-orm-example-ui-kit/package-lock.json
+++ b/examples/forge-sql-orm-example-ui-kit/package-lock.json
@@ -14,12 +14,12 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
+        "forge-sql-orm": "^2.2.0",
         "react": "^18.2.0"
       },
       "devDependencies": {
         "eslint-plugin-react-hooks": "^7.1.1",
-        "forge-sql-orm-cli": "^2.1.29",
+        "forge-sql-orm-cli": "^2.2.0",
         "knip": "^6.16.0"
       }
     },
@@ -6473,16 +6473,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -7176,9 +7166,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7196,9 +7183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7216,9 +7200,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7236,9 +7217,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7256,9 +7234,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7276,9 +7251,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7296,9 +7268,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7316,9 +7285,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7531,9 +7497,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7548,9 +7511,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7565,9 +7525,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7582,9 +7539,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7599,9 +7553,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7616,9 +7567,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7633,9 +7581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7650,9 +7595,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7894,13 +7836,6 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -8037,16 +7972,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/bind-event-listener": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
@@ -8128,9 +8053,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -8208,13 +8133,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -9121,38 +9046,36 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/forge-sql-orm-cli": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.1.29.tgz",
-      "integrity": "sha512-mHTv6eUuCkmLlpdb0jt0aSNy8M2TAZ02jL9uet3mgcb7SDVu4pA7Dmu2FZ3JsamHK1nQWIlx7YqgXNoptqrG/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm-cli/-/forge-sql-orm-cli-2.2.0.tgz",
+      "integrity": "sha512-raYDp4Vhskx7U8b/hMKc8K/vCW62NatWgZeV0TlQ5dRhpX0zYIL0k9HQUv4E09BvPV/QYdJ5V1XppcPdmxSoGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
-        "inquirer": "^13.4.3",
-        "mysql2": "^3.22.3",
+        "forge-sql-orm": "^2.2.0",
+        "inquirer": "^14.0.2",
+        "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -9418,22 +9341,21 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
-      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.0.2.tgz",
+      "integrity": "sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.10",
-        "@inquirer/prompts": "^8.4.3",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/prompts": "^8.5.2",
+        "@inquirer/type": "^4.0.7",
         "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
+        "run-async": "^4.0.6"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -9925,20 +9847,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {
@@ -10677,16 +10585,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safer-buffer": {

--- a/examples/forge-sql-orm-example-ui-kit/package.json
+++ b/examples/forge-sql-orm-example-ui-kit/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "eslint-plugin-react-hooks": "^7.1.1",
-    "forge-sql-orm-cli": "^2.1.29",
+    "forge-sql-orm-cli": "^2.2.0",
     "knip": "^6.16.0"
   },
   "dependencies": {
@@ -23,7 +23,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29",
+    "forge-sql-orm": "^2.2.0",
     "react": "^18.2.0"
   }
 }

--- a/examples/forge-sql-orm-example-vector/package-lock.json
+++ b/examples/forge-sql-orm-example-vector/package-lock.json
@@ -12,7 +12,7 @@
         "@forge/resolver": "1.8.0",
         "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29"
+        "forge-sql-orm": "^2.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",
@@ -100,16 +100,6 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
       }
     },
     "node_modules/@forge/manifest": {
@@ -296,9 +286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -316,9 +303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,9 +320,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,9 +337,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -376,9 +354,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,9 +371,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,9 +388,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -436,9 +405,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,9 +617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,9 +631,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,9 +645,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,9 +659,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,9 +673,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,9 +687,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,9 +701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +715,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,13 +866,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -971,16 +906,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -1327,21 +1252,19 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -1562,20 +1485,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {

--- a/examples/forge-sql-orm-example-vector/package.json
+++ b/examples/forge-sql-orm-example-vector/package.json
@@ -8,7 +8,7 @@
     "@forge/resolver": "1.8.0",
     "@forge/sql": "^3.0.25",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29"
+    "forge-sql-orm": "^2.2.0"
   },
   "scripts": {
     "build:ci": "tsc --target esnext --project tsconfig.json --ignoreDeprecations 6.0 --outDir dist && rm -rf dist",

--- a/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
@@ -1254,9 +1254,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1274,9 +1271,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,9 +1288,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1314,9 +1305,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1334,9 +1322,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1354,9 +1339,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,9 +1356,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1394,9 +1373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1599,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1643,9 +1613,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,9 +1627,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,9 +1641,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,9 +1655,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,9 +1669,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1728,9 +1683,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1901,9 +1853,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,9 +1870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1941,9 +1887,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1961,9 +1904,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1981,9 +1921,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2001,9 +1938,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3390,9 +3324,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3414,9 +3345,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3438,9 +3366,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3462,9 +3387,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/forge-sql-orm-cli/README.md
+++ b/forge-sql-orm-cli/README.md
@@ -36,7 +36,7 @@ npm install forge-sql-orm-cli -D
 npm install forge-sql-orm-cli@npm:@forge-sql-orm/forge-sql-orm-cli@latest -D
 ```
 
-Requires a project `.npmrc` for `@forge-sql-orm` — see [core README — Installing from GitHub Packages](../README.md#installing-from-github-packages-weekly-latest). Official stable releases remain on [npmjs.com](https://www.npmjs.com/package/forge-sql-orm-cli).
+Requires a project `.npmrc` for `@forge-sql-orm` — see [core README — Installing from GitHub Packages](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md#installing-from-github-packages-weekly-latest). Official stable releases remain on [npmjs.com](https://www.npmjs.com/package/forge-sql-orm-cli).
 
 # Basic installation for UI-Kit projects
 

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
-        "forge-sql-orm": "^2.1.29",
+        "forge-sql-orm": "^2.2.0",
         "inquirer": "^14.0.2",
         "mysql2": "^3.22.4",
         "reflect-metadata": "^0.2.2",
@@ -1131,16 +1131,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@forge/kvs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.6.4.tgz",
-      "integrity": "sha512-0kKiecZk0IgO7wEpRdOlCph9J9ktjgk1VqSH8zDhOfimoDAj15UhQngmyDmviqBy5xalz2Vg6f6No/P6FZj7Wg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "dependencies": {
-        "@forge/api": "^7.2.1"
-      }
-    },
     "node_modules/@forge/manifest": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.8.0.tgz",
@@ -1763,9 +1753,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1783,9 +1770,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1803,9 +1787,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1823,9 +1804,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1843,9 +1821,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1863,9 +1838,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1883,9 +1855,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1903,9 +1872,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,9 +2084,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2152,9 +2112,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2169,9 +2126,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,9 +2140,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,9 +2154,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,9 +2168,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,9 +2182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2400,9 +2342,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,9 +2359,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2440,9 +2376,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,9 +2393,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,9 +2410,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,9 +2427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,13 +2643,6 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
-    },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
@@ -3200,16 +3117,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/boolbase": {
@@ -4565,21 +4472,19 @@
       "peer": true
     },
     "node_modules/forge-sql-orm": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.1.29.tgz",
-      "integrity": "sha512-by2DqwhbF+dlnKVIE1b1qGhbexFiECVyBO3jObptt64a1HVJY+wHl9W/U8L7OyDhGhNZPZs7AiMigl179gS07Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
       "license": "MIT",
       "dependencies": {
-        "@forge/api": "^7.2.0",
+        "@forge/api": "^7.2.1",
         "luxon": "^3.7.2"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4",
-        "@forge/kvs": "^1.6.2",
-        "node-sql-parser": "^5.4.0"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
-        "@forge/sql": "^3.0.24",
+        "@forge/sql": "^3.0.25",
         "drizzle-orm": "^0.45.2"
       }
     },
@@ -5102,9 +5007,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5126,9 +5028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5150,9 +5049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5174,9 +5070,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5468,20 +5361,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-sql-orm-cli",
-  "version": "2.1.29",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-sql-orm-cli",
-      "version": "2.1.29",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/forge-sql-orm-cli/package.json
+++ b/forge-sql-orm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-sql-orm-cli",
-  "version": "2.1.29",
+  "version": "2.2.0",
   "description": "CLI tool for Forge SQL ORM",
   "main": "dist-cli/cli.js",
   "types": "dist-cli/cli.d.ts",
@@ -49,7 +49,7 @@
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
-    "forge-sql-orm": "^2.1.29",
+    "forge-sql-orm": "^2.2.0",
     "inquirer": "^14.0.2",
     "mysql2": "^3.22.4",
     "reflect-metadata": "^0.2.2",

--- a/forge-sql-orm-extra/README.md
+++ b/forge-sql-orm-extra/README.md
@@ -9,7 +9,7 @@
 
 [![forge-sql-orm CI](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml/badge.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml)
 
-**Forge SQL ORM Extra** is the extended edition of [forge-sql-orm](../README.md) — a TypeScript ORM for [Atlassian Forge](https://developer.atlassian.com/platform/forge/) apps that use [@forge/sql](https://developer.atlassian.com/platform/forge/storage-reference/sql-tutorial/). It includes everything from the core package (Drizzle integration, migrations, local cache, optimistic locking, query analysis) and adds capabilities that need [@forge/kvs](https://developer.atlassian.com/platform/forge/storage-reference/storage-api-custom-entities/) or Rovo.
+**Forge SQL ORM Extra** is the extended edition of [forge-sql-orm](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md) — a TypeScript ORM for [Atlassian Forge](https://developer.atlassian.com/platform/forge/) apps that use [@forge/sql](https://developer.atlassian.com/platform/forge/storage-reference/sql-tutorial/). It includes everything from the core package (Drizzle integration, migrations, local cache, optimistic locking, query analysis) and adds capabilities that need [@forge/kvs](https://developer.atlassian.com/platform/forge/storage-reference/storage-api-custom-entities/) or Rovo.
 
 Use **`forge-sql-orm-extra`** instead of **`forge-sql-orm`** when you want a single import that covers both everyday Forge SQL work and the extras below. The public API is the same `ForgeSQL` class — extended methods sit alongside the core ones.
 
@@ -22,7 +22,7 @@ Use **`forge-sql-orm-extra`** instead of **`forge-sql-orm`** when you want a sin
 | Level 2 global query cache via `@forge/kvs`      | —                      | ✅ `selectCacheable*`, `executeCacheable`, cache eviction helpers |
 | Rovo natural-language analytics with RLS         | —                      | ✅ `forgeSQL.rovo()`                                              |
 
-Install **forge-sql-orm-extra** when you need cross-invocation caching or Rovo. For Forge SQL apps without those features, [forge-sql-orm](../README.md) alone is enough.
+Install **forge-sql-orm-extra** when you need cross-invocation caching or Rovo. For Forge SQL apps without those features, [forge-sql-orm](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md) alone is enough.
 
 ## Installation
 
@@ -40,7 +40,7 @@ npm install forge-sql-orm-extra @forge/kvs -S
 
 You still need `forge-sql-orm`, `@forge/sql`, and `drizzle-orm` in the project (install the core line above if they are not already present).
 
-**Weekly `latest` from GitHub Packages** — same quality-gated snapshots as [core README — Installing from GitHub Packages](../README.md#installing-from-github-packages-weekly-latest). Example:
+**Weekly `latest` from GitHub Packages** — same quality-gated snapshots as [core README — Installing from GitHub Packages](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md#installing-from-github-packages-weekly-latest). Example:
 
 ```bash
 npm install forge-sql-orm@npm:@forge-sql-orm/forge-sql-orm@latest \
@@ -157,7 +157,7 @@ The diagram below shows the lifecycle of a cacheable query in Forge-SQL-ORM:
    - Cache miss / expired → query is executed against @forge/sql.
 4. Fresh result is stored in @forge/kvs with TTL and returned to the caller.
 
-![img.png](../img/umlCache1.png)
+![img.png](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/master/img/umlCache1.png)
 
 The diagram below shows how Evict Cache works in Forge-SQL-ORM:
 
@@ -167,7 +167,7 @@ The diagram below shows how Evict Cache works in Forge-SQL-ORM:
 4. Once eviction is complete, the update result is returned to the resolver.
 5. **Note:** Expired entries are not processed here — they are cleaned up separately by the scheduled cache cleanup trigger using the `expiration` index.
 
-![img.png](../img/umlCacheEvict1.png)
+![img.png](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/master/img/umlCacheEvict1.png)
 
 The diagram below shows how Scheduled Expiration Cleanup works:
 
@@ -178,7 +178,7 @@ The diagram below shows how Scheduled Expiration Cleanup works:
 3. Entries are deleted in batches (up to 25 per transaction) until the page is empty; pagination is done with a cursor (e.g., 100 per page).
 4. This keeps the cache footprint small. Use this trigger only when needed; poor INSERT/UPDATE performance should be addressed by cache design first.
 
-![img.png](../img/umlCacheEvictScheduler1.png)
+![img.png](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/master/img/umlCacheEvictScheduler1.png)
 
 The diagram below shows how Cache Context works:
 
@@ -192,7 +192,7 @@ The diagram below shows how Cache Context works:
 5. Matching cache entries are deleted in **batches** (≤25 per transaction) until the page is exhausted; then the next page is fetched via the cursor.
 6. Expiration is handled separately by the scheduled cleanup and is **not part of** the context flow.
 
-![img.png](../img/umlCacheEvictCacheContext1.png)
+![img.png](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/master/img/umlCacheEvictCacheContext1.png)
 
 ### Important Considerations
 
@@ -509,7 +509,7 @@ where Cache context - allows you to batch cache invalidation events and bypass c
 
 [↑ Back to Top](#table-of-contents)
 
-This section documents **Level 2 only** (moved to **forge-sql-orm-extra**). Level 1 (local cache) is documented below and in the [core README](../README.md#usage-approaches); it does not require `@forge/kvs`.
+This section documents **Level 2 only** (moved to **forge-sql-orm-extra**). Level 1 (local cache) is documented below and in the [core README](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md#usage-approaches); it does not require `@forge/kvs`.
 
 **forge-sql-orm-extra** provides a global caching system that provides **cross-invocation caching** - the ability to share cached data between different resolver invocations. The global cache system is built on top of [@forge/kvs Custom entity store](https://developer.atlassian.com/platform/forge/storage-reference/storage-api-custom-entities/) and provides persistent cross-invocation caching with automatic serialization/deserialization of complex data structures.
 
@@ -535,7 +535,7 @@ Default backends differ by package:
 
 **If you used global cache before (2.1.x monolith):** install and import **`forge-sql-orm-extra`** instead of `forge-sql-orm`. You do not need to change `cacheEntityName`, TTL, or query code — only the import (and dependencies). `KVSCache` is already the default on this package.
 
-The backend is still pluggable via `cacheImplementation` ([`Cache`](../src/lib/cache/Cache.ts) interface from core). Override only for custom implementations or tests:
+The backend is still pluggable via `cacheImplementation` ([`Cache`](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/src/lib/cache/Cache.ts) interface from core). Override only for custom implementations or tests:
 
 ```typescript
 import ForgeSQL from "forge-sql-orm-extra";
@@ -606,7 +606,7 @@ await forgeSQL.executeWithCacheContext(async () => {
 
 ### Local Cache Operations (Level 1)
 
-> **Package note:** Local cache is **core** functionality ([forge-sql-orm](../README.md)); it did **not** move to extra. This section describes L1 for apps using **forge-sql-orm-extra** (L1 + L2). For L1 only, use core `forge-sql-orm` without `@forge/kvs`.
+> **Package note:** Local cache is **core** functionality ([forge-sql-orm](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md)); it did **not** move to extra. This section describes L1 for apps using **forge-sql-orm-extra** (L1 + L2). For L1 only, use core `forge-sql-orm` without `@forge/kvs`.
 
 Forge-SQL-ORM provides a local cache system (Level 1 cache) that stores query results in memory for the duration of a single resolver invocation. This is particularly useful for optimizing repeated queries within the same execution context(resolver invocation).
 
@@ -817,7 +817,7 @@ The diagram below shows how local cache works in Forge-SQL-ORM:
 5. **Query After Modification**: Cache miss (was evicted) → Database query → Save to local cache
 6. **Request End**: Local cache context is destroyed, all data cleared
 
-![Local Cache Flow](../img/localCacheFlow.txt)
+![Local Cache Flow](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/master/img/umlLocalCache.png)
 
 ### Cache-Aware Query Operations
 
@@ -1155,7 +1155,7 @@ export async function runSecurityNotesQuery(
 
 ## ForgeSqlOrmOptions (cache)
 
-When using `forge-sql-orm-extra`, these options apply in addition to [core options](../README.md#forgesqlormoptions):
+When using `forge-sql-orm-extra`, these options apply in addition to [core options](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md#forgesqlormoptions):
 
 | Option                | Type      | Description                                                                                                                                    |
 | --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1167,12 +1167,12 @@ When using `forge-sql-orm-extra`, these options apply in addition to [core optio
 
 ## Examples
 
-- [Cache Example](../examples/forge-sql-orm-example-cache) — caching with performance monitoring
+- [Cache Example](https://github.com/forge-sql-orm/forge-sql-orm/tree/master/examples/forge-sql-orm-example-cache) — caching with performance monitoring
 - [Rovo Integration Example](https://github.com/vzakharchenko/Forge-Secure-Notes-for-Jira) — secure natural-language analytics
 
 ## See also
 
-- [Forge SQL ORM (core)](../README.md) — Drizzle driver, migrations, optimistic locking, local cache, vectors, CLI
+- [Forge SQL ORM (core)](https://github.com/forge-sql-orm/forge-sql-orm/blob/master/README.md) — Drizzle driver, migrations, optimistic locking, local cache, vectors, CLI
 
 ## License
 

--- a/forge-sql-orm-extra/package-lock.json
+++ b/forge-sql-orm-extra/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@forge/kvs": "^1.6.4",
         "@forge/sql": "^3.0.25",
-        "forge-sql-orm": "file:..",
+        "forge-sql-orm": "^2.2.0",
         "luxon": "^3.7.2",
         "node-sql-parser": "^5.4.0"
       },
@@ -22,42 +22,6 @@
         "license-checker-rseidelsohn": "^5.0.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
-      }
-    },
-    "..": {
-      "version": "2.1.29",
-      "license": "MIT",
-      "dependencies": {
-        "@forge/api": "^7.2.1",
-        "luxon": "^3.7.2"
-      },
-      "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "@types/luxon": "^3.7.1",
-        "@types/node": "^25.9.2",
-        "@typescript-eslint/eslint-plugin": "^8.60.1",
-        "@typescript-eslint/parser": "^8.60.1",
-        "@vitest/coverage-v8": "^4.1.8",
-        "@vitest/eslint-plugin": "^1.6.19",
-        "@vitest/ui": "^4.1.8",
-        "eslint": "^10.4.1",
-        "eslint-config-prettier": "^10.1.8",
-        "globals": "^17.6.0",
-        "husky": "^9.1.7",
-        "knip": "^6.16.0",
-        "lcov-result-merger": "^6.0.0",
-        "license-checker-rseidelsohn": "^5.0.1",
-        "prettier": "^3.8.3",
-        "ts-node": "^10.9.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.8"
-      },
-      "optionalDependencies": {
-        "@forge/events": "^2.1.6"
-      },
-      "peerDependencies": {
-        "@forge/sql": "^3.0.25",
-        "drizzle-orm": "^0.45.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -182,6 +146,16 @@
       "resolved": "https://registry.npmjs.org/@forge/egress/-/egress-2.3.2.tgz",
       "integrity": "sha512-p8ioX4qnAlRFln+hyH9kO0MmVCSOUg0bsIG9RAYK8KM2YaJb6EnKqbCvPMBTwegiua3vixBsnZmWDgPegSZh9Q==",
       "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@forge/events": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@forge/events/-/events-2.1.6.tgz",
+      "integrity": "sha512-tVtkXdKYN2pbHDjA5GcPt4Ny4mdi2Ee7Z93ECOUeJXL25NahbnoZSROMMWwF8hakmC4m6iGcID1rP1d8CMUJrQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "dependencies": {
+        "@forge/api": "7.2.1"
+      }
     },
     "node_modules/@forge/i18n": {
       "version": "0.0.7",
@@ -2260,6 +2234,132 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -2380,8 +2480,21 @@
       }
     },
     "node_modules/forge-sql-orm": {
-      "resolved": "..",
-      "link": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/forge-sql-orm/-/forge-sql-orm-2.2.0.tgz",
+      "integrity": "sha512-Mqoty0Y5XZ07VWlTdg+D29++I4KDUSjRUQMLV8KsyjFcRNbe6s6yYvTmg4/pQYJLZBKyqiCMXLjQuxJFHjYLqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@forge/api": "^7.2.1",
+        "luxon": "^3.7.2"
+      },
+      "optionalDependencies": {
+        "@forge/events": "^2.1.6"
+      },
+      "peerDependencies": {
+        "@forge/sql": "^3.0.25",
+        "drizzle-orm": "^0.45.2"
+      }
     },
     "node_modules/formatly": {
       "version": "0.3.0",

--- a/forge-sql-orm-extra/package-lock.json
+++ b/forge-sql-orm-extra/package-lock.json
@@ -53,7 +53,7 @@
         "vitest": "^4.1.8"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
         "@forge/sql": "^3.0.25",
@@ -704,9 +704,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +721,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +738,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,9 +755,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +772,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -804,9 +789,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -824,9 +806,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -844,9 +823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,9 +1035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,9 +1049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1093,9 +1063,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,9 +1077,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,9 +1091,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,9 +1105,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,9 +1119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,9 +1133,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,9 +1293,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,9 +1310,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,9 +1327,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1401,9 +1344,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1421,9 +1361,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,9 +1378,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3003,9 +2937,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3027,9 +2958,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3051,9 +2979,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3075,9 +3000,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/forge-sql-orm-extra/package.json
+++ b/forge-sql-orm-extra/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@forge/kvs": "^1.6.4",
     "@forge/sql": "^3.0.25",
-    "forge-sql-orm": "file:..",
+    "forge-sql-orm": "^2.2.0",
     "luxon": "^3.7.2",
     "node-sql-parser": "^5.4.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-sql-orm",
-  "version": "2.1.29",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-sql-orm",
-      "version": "2.1.29",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@forge/api": "^7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vitest": "^4.1.8"
       },
       "optionalDependencies": {
-        "@forge/events": "^2.1.4"
+        "@forge/events": "^2.1.6"
       },
       "peerDependencies": {
         "@forge/sql": "^3.0.25",
@@ -982,9 +982,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,9 +999,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,9 +1016,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1042,9 +1033,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,9 +1050,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1082,9 +1067,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,9 +1084,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1122,9 +1101,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1313,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1354,9 +1327,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1371,9 +1341,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1388,9 +1355,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1405,9 +1369,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,9 +1383,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1439,9 +1397,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1456,9 +1411,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1578,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1646,9 +1595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1666,9 +1612,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1686,9 +1629,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,9 +1646,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1663,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4406,9 +4340,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4430,9 +4361,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4454,9 +4382,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4478,9 +4403,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-sql-orm",
-  "version": "2.1.29",
+  "version": "2.2.0",
   "description": "Drizzle ORM integration for Atlassian @forge/sql. Custom driver, schema migration, local in-memory cache, optimistic locking, and query analysis. Use forge-sql-orm-extra for @forge/kvs global cache and Rovo.",
   "main": "dist/index.js",
   "homepage": "https://github.com/forge-sql-orm/forge-sql-orm#readme",
@@ -81,7 +81,7 @@
     "luxon": "^3.7.2"
   },
   "optionalDependencies": {
-    "@forge/events": "^2.1.4"
+    "@forge/events": "^2.1.6"
   },
   "lint-staged": {
     "{src,forge-sql-orm-cli/src,__tests__,examples}/**/*.{ts,tsx,mts,cts}": [


### PR DESCRIPTION
- Upgraded `forge-sql-orm` and related packages to version `2.2.0`.
- Updated optional dependencies, including `@forge/events` to `^2.1.6`.
- Enhanced autoupdate script to include optional dependencies in updates.
- Updated README links to point to GitHub-hosted documentation.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [ ] I have run `npm run format`
- [ ] I have run `npm run build` (Type checking)
- [ ] I have run `npm run knip` (Dependency check)
- [ ] I have run `npm run lint`
- [ ] I have run `npm run test` and coverage is sufficient (>80%)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved CLI installation guidance for GitHub Packages and refreshed README links/images; finalized changelog for the 2.2.0 release

* **Chores**
  * Bumped core package and CLI to 2.2.0 across examples and extras
  * Switched extra package to published core range and updated optional/core dependency ranges
  * Adjusted dependency-update workflow to include optional dependencies during updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->