### PR TITLE
integrate Codacy coverage upload and update README badges

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -96,17 +96,21 @@ jobs:
           node scripts/ci/github-packages.mjs publish-cli "${{ steps.publish_core.outputs.core_version }}"
           echo "cli_version=$(node scripts/ci/github-packages.mjs ci-version forge-sql-orm-cli)" >> "$GITHUB_OUTPUT"
       - name: Merge library + EXTRA + CLI coverage into a single report
+        if: secrets.SONARCLOUD_TOKEN != '' || secrets.QLTY_COVERAGE_TOKEN != '' || secrets.CODACY_API_TOKEN != ''
         run: npm run coverage:merge
       - name: SonarQube Scan
+        if: secrets.SONARCLOUD_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
       - name: Upload to Qlty
+        if: secrets.QLTY_COVERAGE_TOKEN != ''
         uses: qltysh/qlty-action/coverage@141b881236146435192435eb7b0e06ea0b70b4d9 # main as of 2026-05-12
         with:
           coverage-token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ./coverage/lcov.info
       - name: Upload coverage to Codacy
+        if: secrets.CODACY_API_TOKEN != ''
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           api-token: ${{ secrets.CODACY_API_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,10 @@ jobs:
   # --- Quality gate: core library lint / build / tests / coverage scanners ---
   quality:
     runs-on: ubuntu-latest
+    env:
+      SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
     permissions:
       contents: read
       packages: write
@@ -96,24 +100,24 @@ jobs:
           node scripts/ci/github-packages.mjs publish-cli "${{ steps.publish_core.outputs.core_version }}"
           echo "cli_version=$(node scripts/ci/github-packages.mjs ci-version forge-sql-orm-cli)" >> "$GITHUB_OUTPUT"
       - name: Merge library + EXTRA + CLI coverage into a single report
-        if: secrets.SONARCLOUD_TOKEN != '' || secrets.QLTY_COVERAGE_TOKEN != '' || secrets.CODACY_API_TOKEN != ''
+        if: env.SONARCLOUD_TOKEN != '' || env.QLTY_COVERAGE_TOKEN != '' || env.CODACY_API_TOKEN != ''
         run: npm run coverage:merge
       - name: SonarQube Scan
-        if: secrets.SONARCLOUD_TOKEN != ''
+        if: env.SONARCLOUD_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONARCLOUD_TOKEN }}
       - name: Upload to Qlty
-        if: secrets.QLTY_COVERAGE_TOKEN != ''
+        if: env.QLTY_COVERAGE_TOKEN != ''
         uses: qltysh/qlty-action/coverage@141b881236146435192435eb7b0e06ea0b70b4d9 # main as of 2026-05-12
         with:
-          coverage-token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          coverage-token: ${{ env.QLTY_COVERAGE_TOKEN }}
           files: ./coverage/lcov.info
       - name: Upload coverage to Codacy
-        if: secrets.CODACY_API_TOKEN != ''
+        if: env.CODACY_API_TOKEN != ''
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
-          api-token: ${{ secrets.CODACY_API_TOKEN }}
+          api-token: ${{ env.CODACY_API_TOKEN }}
           coverage-reports: ./coverage/lcov.info
 
   # --- Examples: one matrix entry per example, built & deployed in parallel ---

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -106,6 +106,11 @@ jobs:
         with:
           coverage-token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ./coverage/lcov.info
+      - name: Upload coverage to Codacy
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        with:
+          api-token: ${{ secrets.CODACY_API_TOKEN }}
+          coverage-reports: ./coverage/lcov.info
 
   # --- Examples: one matrix entry per example, built & deployed in parallel ---
   examples:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,27 @@
 # Forge SQL ORM
 
-[![npm version](https://img.shields.io/npm/v/forge-sql-orm)](https://www.npmjs.com/package/forge-sql-orm)
-[![npm downloads](https://img.shields.io/npm/dm/forge-sql-orm)](https://www.npmjs.com/package/forge-sql-orm)
+[![npm version (core)](https://img.shields.io/npm/v/forge-sql-orm?label=core)](https://www.npmjs.com/package/forge-sql-orm)
+[![npm downloads (core)](https://img.shields.io/npm/dm/forge-sql-orm?label=core%20downloads)](https://www.npmjs.com/package/forge-sql-orm)
+[![npm version (extra)](https://img.shields.io/npm/v/forge-sql-orm-extra?label=extra)](https://www.npmjs.com/package/forge-sql-orm-extra)
+[![npm downloads (extra)](https://img.shields.io/npm/dm/forge-sql-orm-extra?label=extra%20downloads)](https://www.npmjs.com/package/forge-sql-orm-extra)
 [![npm version (CLI)](https://img.shields.io/npm/v/forge-sql-orm-cli?label=cli)](https://www.npmjs.com/package/forge-sql-orm-cli)
 [![npm downloads (CLI)](https://img.shields.io/npm/dm/forge-sql-orm-cli?label=cli%20downloads)](https://www.npmjs.com/package/forge-sql-orm-cli)
 
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=coverage)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![forge-sql-orm CI](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml/badge.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml)
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![Code Coverage](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm/coverage.svg)](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=bugs)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
+
+[![DeepScan grade](https://deepscan.io/api/teams/26652/projects/30920/branches/997203/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=26652&pid=30920&bid=997203)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5a850fba74734c658a5f88822cff4fd0)](https://app.codacy.com/gh/forge-sql-orm/forge-sql-orm/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Snyk Vulnerabilities](https://snyk.io/test/github/forge-sql-orm/forge-sql-orm/badge.svg)](https://snyk.io/test/github/forge-sql-orm/forge-sql-orm)
+[![Maintainability](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm/maintainability.svg)](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm)
+[![Socket Badge](https://badge.socket.dev/npm/package/forge-sql-orm/latest)](https://badge.socket.dev/npm/package/forge-sql-orm/latest)
 
 [![LoC (full)](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/badges/loc-full.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/badge.yml)
 [![LoC (src)](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/badges/loc-src.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/badge.yml)
@@ -14,19 +30,6 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/forge-sql-orm/forge-sql-orm)](https://api.reuse.software/info/github.com/forge-sql-orm/forge-sql-orm)
 [![License compliance (core)](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/badges/license-compliance.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/badge.yml)
 [![License compliance (extra)](https://raw.githubusercontent.com/forge-sql-orm/forge-sql-orm/badges/extra-license-compliance.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/badge.yml)
-
-[![forge-sql-orm CI](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml/badge.svg)](https://github.com/forge-sql-orm/forge-sql-orm/actions/workflows/node.js.yml)
-[![DeepScan grade](https://deepscan.io/api/teams/26652/projects/30920/branches/997203/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=26652&pid=30920&bid=997203)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5a850fba74734c658a5f88822cff4fd0)](https://app.codacy.com/gh/forge-sql-orm/forge-sql-orm/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Snyk Vulnerabilities](https://snyk.io/test/github/forge-sql-orm/forge-sql-orm/badge.svg)](https://snyk.io/test/github/forge-sql-orm/forge-sql-orm)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=bugs)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=forge-sql-orm_forge-sql-orm&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=forge-sql-orm_forge-sql-orm)
-[![Maintainability](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm/maintainability.svg)](https://qlty.sh/gh/forge-sql-orm/projects/forge-sql-orm)
 
 **Forge SQL ORM** is a TypeScript ORM for [Atlassian Forge](https://developer.atlassian.com/platform/forge/) apps that use [@forge/sql](https://developer.atlassian.com/platform/forge/storage-reference/sql-tutorial/) — Atlassian’s managed SQL storage (TiDB-compatible) inside Forge resolvers, triggers, and scheduled jobs.
 


### PR DESCRIPTION


# Description
 integrate Codacy coverage upload and update README badges
- Added Codacy coverage reporter action to GitHub workflow.
- Updated README badges with additional metrics and reformatted sections for clarity.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README badges: replaced generic npm badges with detailed package/version badges, reorganized CI and quality/security metrics, and consolidated coverage & maintenance indicators.

* **Chores**
  * CI workflow: quality and coverage steps now use job-level tokens and run only when relevant reporting credentials are present; added automated coverage upload to Codacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->