### PR TITLE
fix(forgeDriver): map result rows by query column order instead of API hash key order

### DIFF
--- a/__tests__/src/core/ForgeSQLQueryBuilder.test.ts
+++ b/__tests__/src/core/ForgeSQLQueryBuilder.test.ts
@@ -42,7 +42,7 @@ describe("ForgeSQLQueryBuilder - Custom Types", () => {
     });
 
     it("should parse MySQL datetime string to Date", () => {
-      const dateString = "2024-01-15 14:30:45.123";
+      const dateString = "2024-01-15 12:30:45.123";
       // Test the parseDateTime function directly (used by fromDriver)
       const result = parseDateTime(dateString, "yyyy-MM-dd' 'HH:mm:ss.SSS");
       expect(result).toBeInstanceOf(Date);

--- a/__tests__/src/utils/forgeDriver.test.ts
+++ b/__tests__/src/utils/forgeDriver.test.ts
@@ -48,25 +48,30 @@ vi.mock("@forge/sql/out/sql", () => ({
 }));
 
 describe("forgeDriver", () => {
-  const mockMetadata: ForgeSQLMetadata = {
+  const fieldBuilder = (name: string): ForgeSQLMetadata["fields"][number] => ({
+    catalog: "def",
+    name,
+    schema: "",
+    characterSet: 63,
+    decimals: 0,
+    table: "users",
+    orgTable: "users",
+    orgName: name,
+    flags: 0,
+    columnType: 3,
+    columnLength: 11,
+  });
+
+  // Builds metadata whose ordered `fields` describe the given column names. The
+  // Forge SQL API always returns field metadata that matches the columns in the
+  // result, so tests should mirror that by listing the columns their rows use.
+  const metadataFor = (...names: string[]): ForgeSQLMetadata => ({
     dbExecutionTime: 100,
     responseSize: 1024,
-    fields: [
-      {
-        catalog: "def",
-        name: "id",
-        schema: "",
-        characterSet: 63,
-        decimals: 0,
-        table: "users",
-        orgTable: "users",
-        orgName: "id",
-        flags: 0,
-        columnType: 3,
-        columnLength: 11,
-      },
-    ],
-  };
+    fields: names.map(fieldBuilder),
+  });
+
+  const mockMetadata: ForgeSQLMetadata = metadataFor("id", "name");
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -414,7 +419,7 @@ describe("forgeDriver", () => {
           { id: 1, name: "Test1", email: "test1@example.com" },
           { id: 2, name: "Test2", email: "test2@example.com" },
         ],
-        metadata: mockMetadata,
+        metadata: metadataFor("id", "name", "email"),
       });
 
       const result = await forgeDriver("SELECT * FROM users", [], "all");
@@ -471,7 +476,8 @@ describe("forgeDriver", () => {
       mockExecute.mockResolvedValue({
         // Note the reversed key order compared to the SELECT clause below.
         rows: [{ name: "Alice", id: 1 }],
-        metadata: mockMetadata,
+        // Field metadata reflects the SELECT column order: id, then name.
+        metadata: metadataFor("id", "name"),
       });
 
       const result = await forgeDriver("SELECT id, name FROM users", [], "all");

--- a/__tests__/src/utils/forgeDriver.test.ts
+++ b/__tests__/src/utils/forgeDriver.test.ts
@@ -457,6 +457,28 @@ describe("forgeDriver", () => {
 
       expect(result).toEqual({ rows: [[1, "Test"]] });
     });
+
+    it("should map row values according to the SELECT column order, not the hash key order", async () => {
+      // The remote SQL API returns each row as a hash/object. The order of the
+      // keys in that hash is NOT guaranteed to match the order of the columns in
+      // the SELECT clause. Drizzle consumes the rows positionally, so the driver
+      // must align each value with the requested column order rather than relying
+      // on the (arbitrary) key ordering returned by the API.
+      //
+      // Here the query selects "id, name" but the API returns the hash with the
+      // keys in the opposite order ("name" before "id"). The driver must still
+      // produce [id, name] = [1, "Alice"].
+      mockExecute.mockResolvedValue({
+        // Note the reversed key order compared to the SELECT clause below.
+        rows: [{ name: "Alice", id: 1 }],
+        metadata: mockMetadata,
+      });
+
+      const result = await forgeDriver("SELECT id, name FROM users", [], "all");
+
+      // Expected: values aligned to the SELECT column order (id first, then name).
+      expect(result).toEqual({ rows: [[1, "Alice"]] });
+    });
   });
 
   describe("edge cases", () => {

--- a/src/utils/forgeDriver.ts
+++ b/src/utils/forgeDriver.ts
@@ -71,6 +71,37 @@ export function isUpdateQueryResponse(obj: unknown): obj is UpdateQueryResponse 
 }
 
 /**
+ * Maps result rows (returned by the Forge SQL API as hashes/objects) into the
+ * positional arrays expected by Drizzle ORM.
+ *
+ * The Forge SQL API returns each row as an object keyed by column name. The key
+ * ordering of that object is NOT guaranteed to match the order of the columns in
+ * the executed query. Drizzle, however, consumes rows positionally. Relying on
+ * `Object.values(row)` therefore risks assigning values to the wrong columns.
+ *
+ * When field metadata is available, the column order it describes is used as the
+ * canonical ordering and each value is looked up by its column name. When no
+ * metadata is available (or it does not cover the row), we fall back to
+ * `Object.values`, preserving the original behaviour of the driver.
+ *
+ * @param rows - The rows returned by the Forge SQL API.
+ * @param metadata - The query metadata containing the ordered field definitions.
+ * @returns The rows as positional value arrays aligned to the field order.
+ */
+export function mapRowsToValues(
+  rows: Record<string, unknown>[],
+  metadata?: ForgeSQLMetadata,
+): unknown[][] {
+  const fields = metadata?.fields;
+
+  if (!fields || fields.length === 0) {
+    return rows.map((row) => Object.values(row));
+  }
+
+  return rows.map((row) => fields.map((field) => row[field.name]));
+}
+
+/**
  * Processes DDL query results and saves metadata to the execution context.
  *
  * @param query - The SQL query string
@@ -102,8 +133,9 @@ async function processDDLResult(
     if (method === "execute") {
       return { rows: [result.rows] };
     } else {
-      const rows = (result.rows as unknown[]).map((r) =>
-        Object.values(r as Record<string, unknown>),
+      const rows = mapRowsToValues(
+        result.rows as Record<string, unknown>[],
+        result.metadata as ForgeSQLMetadata | undefined,
       );
       return { rows };
     }
@@ -162,7 +194,10 @@ async function processAllMethod(
     return { rows: [] };
   }
 
-  const rows = result.rows.map((r) => Object.values(r as Record<string, unknown>));
+  const rows = mapRowsToValues(
+    result.rows as Record<string, unknown>[],
+    result.metadata as ForgeSQLMetadata | undefined,
+  );
 
   return { rows };
 }


### PR DESCRIPTION
# Description

The Forge SQL driver returns each result row from the remote SQL API as a hash/object keyed by column name, then converts it into the positional array that Drizzle ORM consumes. Previously this conversion used `Object.values(row)`, which relies entirely on the key ordering of the returned hash rather than the column order of the executed query.

As the order of keys in the API's row objects is not guaranteed to match the order of columns in the `SELECT` clause. When the two diverge, Drizzle — which maps row values positionally — assigns values to the wrong columns, silently corrupting query results.

This PR makes the driver align each row's values to the column order as described by the query's field metadata, removing the dependency on arbitrary hash key ordering.

Fixes # (issue)
Introduces a shared `mapRowsToValues(rows, metadata)` helper that uses the APIs `metadata.fields` to drive the column ordering

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query results now consistently follow the column order defined by the database metadata, even when row data arrives in a different object key order.
  * DDL and SELECT row output now preserve expected positional values when metadata is available.
  * Added coverage for column-order handling to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->