### PR TITLE
Fixes flaky query builder test that was loading date without UTC dattime accessors

### DIFF
--- a/__tests__/src/core/ForgeSQLQueryBuilder.test.ts
+++ b/__tests__/src/core/ForgeSQLQueryBuilder.test.ts
@@ -46,9 +46,13 @@ describe("ForgeSQLQueryBuilder - Custom Types", () => {
       // Test the parseDateTime function directly (used by fromDriver)
       const result = parseDateTime(dateString, "yyyy-MM-dd' 'HH:mm:ss.SSS");
       expect(result).toBeInstanceOf(Date);
-      expect(result.getFullYear()).toBe(2024);
-      expect(result.getMonth()).toBe(0); // January (0-indexed)
-      expect(result.getDate()).toBe(15);
+      // parseDateTime parses in UTC (Settings.defaultZone = "utc"), so assert
+      // using UTC accessors. Using local-timezone accessors (getFullYear/
+      // getMonth/getDate) makes this test flaky: on machines east of UTC the
+      // 14:30 UTC instant rolls over to the 16th in local time.
+      expect(result.getUTCFullYear()).toBe(2024);
+      expect(result.getUTCMonth()).toBe(0); // January (0-indexed)
+      expect(result.getUTCDate()).toBe(15);
     });
 
     it("should handle different datetime formats", () => {


### PR DESCRIPTION

# Description

Fixes test code that was calling getDate instead of using the date accessors, resulting in failures on machines where the the timezone was east of the UTC.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## Checklist:

**Important:** I have run the strict pre-commit checks locally.

- [x] I have run `npm run format`
- [x] I have run `npm run build` (Type checking)
- [x] I have run `npm run knip` (Dependency check)
- [x] I have run `npm run lint`
- [x] I have run `npm run test` and coverage is sufficient (>80%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation (if applicable)
