### PR TITLE
chore(deps): daily autoupdate 2026-07-15

### DIFF
--- a/examples/forge-sql-orm-example-atlascamp/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^26.1.1",
         "forge-sql-orm-cli": "^2.2.3",
         "knip": "^6.26.0",
-        "mysql2": "^3.22.6",
+        "mysql2": "^3.23.0",
         "typescript": "^6.0.3"
       }
     },
@@ -2762,9 +2762,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2775,7 +2775,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-atlascamp/package.json
+++ b/examples/forge-sql-orm-example-atlascamp/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^26.1.1",
     "forge-sql-orm-cli": "^2.2.3",
     "knip": "^6.26.0",
-    "mysql2": "^3.22.6",
+    "mysql2": "^3.23.0",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/examples/forge-sql-orm-example-cache/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/package-lock.json
@@ -2762,9 +2762,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2775,7 +2775,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-checklist/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/package-lock.json
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,7 +2729,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package-lock.json
@@ -19,7 +19,7 @@
         "drizzle-kit": "^0.31.10",
         "forge-sql-orm-cli": "^2.2.3",
         "knip": "^6.26.0",
-        "mysql2": "^3.22.6",
+        "mysql2": "^3.23.0",
         "typescript": "^6.0.3"
       }
     },
@@ -2717,9 +2717,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2730,7 +2730,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/package.json
@@ -14,7 +14,7 @@
     "drizzle-kit": "^0.31.10",
     "forge-sql-orm-cli": "^2.2.3",
     "knip": "^6.26.0",
-    "mysql2": "^3.22.6",
+    "mysql2": "^3.23.0",
     "typescript": "^6.0.3"
   },
   "scripts": {

--- a/examples/forge-sql-orm-example-dynamic/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/package-lock.json
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,7 +2728,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/package-lock.json
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,7 +2728,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-org-tracker/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/package-lock.json
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,7 +2728,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-query-analyses/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/package-lock.json
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,7 +2729,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-simple/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/package-lock.json
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,7 +2728,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/examples/forge-sql-orm-example-sql-executor/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/package-lock.json
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2727,7 +2727,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -15,7 +15,7 @@
         "drizzle-orm": "^0.45.2",
         "forge-sql-orm": "^2.2.3",
         "inquirer": "^14.0.2",
-        "mysql2": "^3.22.6",
+        "mysql2": "^3.23.0",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.1"
       },
@@ -4594,9 +4594,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.6.tgz",
-      "integrity": "sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.0.tgz",
+      "integrity": "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA==",
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",
@@ -4606,7 +4606,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"

--- a/forge-sql-orm-cli/package.json
+++ b/forge-sql-orm-cli/package.json
@@ -51,7 +51,7 @@
     "drizzle-orm": "^0.45.2",
     "forge-sql-orm": "^2.2.3",
     "inquirer": "^14.0.2",
-    "mysql2": "^3.22.6",
+    "mysql2": "^3.23.0",
     "reflect-metadata": "^0.2.2",
     "uuid": "^14.0.1"
   },


### PR DESCRIPTION
Automated dependency update produced by `.github/workflows/autoupdate.yml`. Will auto-merge once required checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MySQL database connectivity package to version 3.23.0 across the CLI and example projects.
  - Includes the latest package updates and improvements for supported MySQL integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->