### PR TITLE
chore(deps): daily autoupdate 2026-07-16

### DIFF
--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package-lock.json
@@ -8,14 +8,14 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^24.3.2",
+        "@atlaskit/button": "^24.3.3",
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
-        "@atlaskit/primitives": "^20.6.0",
-        "@atlaskit/section-message": "^9.2.2",
+        "@atlaskit/dynamic-table": "^19.1.2",
+        "@atlaskit/primitives": "^21.0.0",
+        "@atlaskit/section-message": "^9.2.3",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tabs": "^20.1.0",
-        "@atlaskit/textarea": "^9.1.0",
+        "@atlaskit/tabs": "^20.1.1",
+        "@atlaskit/textarea": "^9.1.1",
         "@atlaskit/textfield": "^9.1.0",
         "@forge/bridge": "^6.1.0",
         "@huggingface/transformers": "^4.2.0",
@@ -33,7 +33,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "24.3.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.2.tgz",
-      "integrity": "sha512-CBJcLDxusbOsht4JDsXC8l236nlYO21keBM5aRqm+968PPMqqP5a2dL9AvY6CJrRgFyAJ3p1nlsKNVISUD59uQ==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.3.tgz",
+      "integrity": "sha512-bp1sh7yXKh/sh32Zaj1C5TcQLT1AD0f1k9bJX29SMRod5e0g5ff96WiQ+hl7UEvFrt3eU1I1t4WYzXB0uqzR/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.3.0",
@@ -178,11 +178,11 @@
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.6.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@atlaskit/button/node_modules/@atlaskit/tokens": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.7.0.tgz",
-      "integrity": "sha512-gojVuCheaOhWNDOulE+wo9eJMrxNhcQviBvj02Fo5Z9Rhstm6PwXkQYeAnXHHf2uyugaEbNCukKj3mFBA6VEmg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -287,21 +287,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -426,10 +426,35 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/heading/node_modules/@atlaskit/primitives": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
+      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@atlaskit/heading/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -507,16 +532,16 @@
       }
     },
     "node_modules/@atlaskit/link": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.1.0.tgz",
-      "integrity": "sha512-YaxFmoyXcuCH3XXto/My4JNPaPngLtu0YfWqL0z8ec5hGMjAwlRnVR37u5hd5TvUvDwgQlAwb+bdSDt2l8V0zw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.3.1.tgz",
+      "integrity": "sha512-fbnBI+siZ2THN2GuV5pkvYU1JxeZvbiWuTF/GQRiazOiqui28kAtnw7GrmCPlR3s96GaXbp2w0KLgoReeZZJUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -525,9 +550,9 @@
       }
     },
     "node_modules/@atlaskit/link/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -602,10 +627,35 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/pagination/node_modules/@atlaskit/primitives": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
+      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@atlaskit/pagination/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -759,18 +809,18 @@
       }
     },
     "node_modules/@atlaskit/primitives": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
-      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/app-provider": "^5.1.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0",
@@ -784,9 +834,9 @@
       }
     },
     "node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.6.0.tgz",
-      "integrity": "sha512-U1AJODBzYnLM0G/a7LgVJKf+J59GMimWHAtGnz4qSvBoFqMHcZWhf7t6nSn8JtDVoR7uVvTNwLnnUEp7IxSfOw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -812,20 +862,20 @@
       }
     },
     "node_modules/@atlaskit/section-message": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.2.tgz",
-      "integrity": "sha512-d43n9sNhHAqJPZuq8D5JdhpRnYTOr5CBwHvG4OGTd79+Yi7KYdJeuZhrR5iDtr+XZ65y3hRUM069QgYA5m++VA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.3.tgz",
+      "integrity": "sha512-JVu7ZaTcgbcsI1J7sN9mS3Sdqy3CUNDDiNQ31U+1FQ61Efu5UlIPv7IhIrKrb9l/ETS61PtB9TgW+XyV1ogP8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/button": "^24.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/heading": "^6.2.0",
         "@atlaskit/icon": "^37.0.0",
-        "@atlaskit/link": "^4.1.0",
+        "@atlaskit/link": "^4.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0"
       },
       "peerDependencies": {
@@ -849,9 +899,9 @@
       }
     },
     "node_modules/@atlaskit/section-message/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -936,16 +986,16 @@
       }
     },
     "node_modules/@atlaskit/tabs": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.0.tgz",
-      "integrity": "sha512-5tco3/aP6rXE8F2eIJLtCoVudUkI3juxxD7hv/H/hi6EogkD9iK+GtwA1jDaXLkLODSPvEHzNZz8ZBeA9Np6jw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.1.tgz",
+      "integrity": "sha512-/NWjazkafGfM2dbophjIn5sTEgKX0F8KC0xNcNTPPUSp2upZ7rLg/r1iDvS5ynLIzYhHKH+mWK35T/gf6exWXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -954,9 +1004,9 @@
       }
     },
     "node_modules/@atlaskit/tabs/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -972,17 +1022,17 @@
       }
     },
     "node_modules/@atlaskit/textarea": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/textarea/-/textarea-9.1.0.tgz",
-      "integrity": "sha512-+mUy+3Ygd1acyIhW45fuSrJBp2YsZC6DhUnYkhqmDsYoge3HhfrxOowc2hT+FMxdIBRWAypxaaKNmcJXxJaXIg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/textarea/-/textarea-9.1.1.tgz",
+      "integrity": "sha512-WkeGIg3voTdNBmh1t31YxDIIx3+u25Csq/5aby2k3ztfhf2Ff7UAcRVGS19tF89PxDmj9nQhmVKkrnOa5Gy0KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -991,9 +1041,9 @@
       }
     },
     "node_modules/@atlaskit/textarea/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -5456,9 +5506,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5758,9 +5808,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -6530,16 +6580,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-ai/static/forge-orm-example/package.json
@@ -4,14 +4,14 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^24.3.2",
+    "@atlaskit/button": "^24.3.3",
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
-    "@atlaskit/primitives": "^20.6.0",
-    "@atlaskit/section-message": "^9.2.2",
+    "@atlaskit/dynamic-table": "^19.1.2",
+    "@atlaskit/primitives": "^21.0.0",
+    "@atlaskit/section-message": "^9.2.3",
     "@atlaskit/spinner": "^20.1.0",
-    "@atlaskit/tabs": "^20.1.0",
-    "@atlaskit/textarea": "^9.1.0",
+    "@atlaskit/tabs": "^20.1.1",
+    "@atlaskit/textarea": "^9.1.1",
     "@atlaskit/textfield": "^9.1.0",
     "@forge/bridge": "^6.1.0",
     "@huggingface/transformers": "^4.2.0",
@@ -29,7 +29,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -3323,9 +3323,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -4031,16 +4031,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-atlascamp/static/forge-orm-example/package.json
@@ -19,7 +19,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-backend-ai/ai-lib/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/ai-lib/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "esbuild": "^0.28.1",
         "rollup-plugin-copy": "^3.5.0",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vite-plugin-static-copy": "^4.1.1"
       }
     },
@@ -2938,16 +2938,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-backend-ai/ai-lib/package.json
+++ b/examples/forge-sql-orm-example-backend-ai/ai-lib/package.json
@@ -18,6 +18,6 @@
     "esbuild": "^0.28.1",
     "rollup-plugin-copy": "^3.5.0",
     "vite-plugin-static-copy": "^4.1.1",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   }
 }

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package-lock.json
@@ -8,13 +8,13 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^24.3.2",
+        "@atlaskit/button": "^24.3.3",
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
-        "@atlaskit/primitives": "^20.6.0",
-        "@atlaskit/section-message": "^9.2.2",
-        "@atlaskit/tabs": "^20.1.0",
-        "@atlaskit/textarea": "^9.1.0",
+        "@atlaskit/dynamic-table": "^19.1.2",
+        "@atlaskit/primitives": "^21.0.0",
+        "@atlaskit/section-message": "^9.2.3",
+        "@atlaskit/tabs": "^20.1.1",
+        "@atlaskit/textarea": "^9.1.1",
         "@atlaskit/textfield": "^9.1.0",
         "@forge/bridge": "^6.1.0",
         "react": "^18.3.1",
@@ -31,7 +31,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "24.3.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.2.tgz",
-      "integrity": "sha512-CBJcLDxusbOsht4JDsXC8l236nlYO21keBM5aRqm+968PPMqqP5a2dL9AvY6CJrRgFyAJ3p1nlsKNVISUD59uQ==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.3.tgz",
+      "integrity": "sha512-bp1sh7yXKh/sh32Zaj1C5TcQLT1AD0f1k9bJX29SMRod5e0g5ff96WiQ+hl7UEvFrt3eU1I1t4WYzXB0uqzR/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.3.0",
@@ -176,11 +176,11 @@
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.6.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@atlaskit/button/node_modules/@atlaskit/tokens": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.7.0.tgz",
-      "integrity": "sha512-gojVuCheaOhWNDOulE+wo9eJMrxNhcQviBvj02Fo5Z9Rhstm6PwXkQYeAnXHHf2uyugaEbNCukKj3mFBA6VEmg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -285,21 +285,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -424,10 +424,35 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/heading/node_modules/@atlaskit/primitives": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
+      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@atlaskit/heading/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -505,16 +530,16 @@
       }
     },
     "node_modules/@atlaskit/link": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.1.0.tgz",
-      "integrity": "sha512-YaxFmoyXcuCH3XXto/My4JNPaPngLtu0YfWqL0z8ec5hGMjAwlRnVR37u5hd5TvUvDwgQlAwb+bdSDt2l8V0zw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.3.1.tgz",
+      "integrity": "sha512-fbnBI+siZ2THN2GuV5pkvYU1JxeZvbiWuTF/GQRiazOiqui28kAtnw7GrmCPlR3s96GaXbp2w0KLgoReeZZJUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -523,9 +548,9 @@
       }
     },
     "node_modules/@atlaskit/link/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -600,10 +625,35 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/pagination/node_modules/@atlaskit/primitives": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
+      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@atlaskit/pagination/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -757,18 +807,18 @@
       }
     },
     "node_modules/@atlaskit/primitives": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
-      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/app-provider": "^5.1.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0",
@@ -782,9 +832,9 @@
       }
     },
     "node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.6.0.tgz",
-      "integrity": "sha512-U1AJODBzYnLM0G/a7LgVJKf+J59GMimWHAtGnz4qSvBoFqMHcZWhf7t6nSn8JtDVoR7uVvTNwLnnUEp7IxSfOw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -810,20 +860,20 @@
       }
     },
     "node_modules/@atlaskit/section-message": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.2.tgz",
-      "integrity": "sha512-d43n9sNhHAqJPZuq8D5JdhpRnYTOr5CBwHvG4OGTd79+Yi7KYdJeuZhrR5iDtr+XZ65y3hRUM069QgYA5m++VA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.3.tgz",
+      "integrity": "sha512-JVu7ZaTcgbcsI1J7sN9mS3Sdqy3CUNDDiNQ31U+1FQ61Efu5UlIPv7IhIrKrb9l/ETS61PtB9TgW+XyV1ogP8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/button": "^24.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/heading": "^6.2.0",
         "@atlaskit/icon": "^37.0.0",
-        "@atlaskit/link": "^4.1.0",
+        "@atlaskit/link": "^4.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0"
       },
       "peerDependencies": {
@@ -847,9 +897,9 @@
       }
     },
     "node_modules/@atlaskit/section-message/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -934,16 +984,16 @@
       }
     },
     "node_modules/@atlaskit/tabs": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.0.tgz",
-      "integrity": "sha512-5tco3/aP6rXE8F2eIJLtCoVudUkI3juxxD7hv/H/hi6EogkD9iK+GtwA1jDaXLkLODSPvEHzNZz8ZBeA9Np6jw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.1.tgz",
+      "integrity": "sha512-/NWjazkafGfM2dbophjIn5sTEgKX0F8KC0xNcNTPPUSp2upZ7rLg/r1iDvS5ynLIzYhHKH+mWK35T/gf6exWXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -952,9 +1002,9 @@
       }
     },
     "node_modules/@atlaskit/tabs/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -970,17 +1020,17 @@
       }
     },
     "node_modules/@atlaskit/textarea": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/textarea/-/textarea-9.1.0.tgz",
-      "integrity": "sha512-+mUy+3Ygd1acyIhW45fuSrJBp2YsZC6DhUnYkhqmDsYoge3HhfrxOowc2hT+FMxdIBRWAypxaaKNmcJXxJaXIg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/textarea/-/textarea-9.1.1.tgz",
+      "integrity": "sha512-WkeGIg3voTdNBmh1t31YxDIIx3+u25Csq/5aby2k3ztfhf2Ff7UAcRVGS19tF89PxDmj9nQhmVKkrnOa5Gy0KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -989,9 +1039,9 @@
       }
     },
     "node_modules/@atlaskit/textarea/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4695,9 +4745,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4939,9 +4989,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5577,16 +5627,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-backend-ai/static/forge-orm-example/package.json
@@ -4,13 +4,13 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^24.3.2",
+    "@atlaskit/button": "^24.3.3",
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
-    "@atlaskit/primitives": "^20.6.0",
-    "@atlaskit/section-message": "^9.2.2",
-    "@atlaskit/tabs": "^20.1.0",
-    "@atlaskit/textarea": "^9.1.0",
+    "@atlaskit/dynamic-table": "^19.1.2",
+    "@atlaskit/primitives": "^21.0.0",
+    "@atlaskit/section-message": "^9.2.3",
+    "@atlaskit/tabs": "^20.1.1",
+    "@atlaskit/textarea": "^9.1.1",
     "@atlaskit/textfield": "^9.1.0",
     "@forge/bridge": "^6.1.0",
     "react": "^18.3.1",
@@ -27,7 +27,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-cache/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-cache/static/forge-orm-example/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -3312,9 +3312,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3502,9 +3502,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -4020,16 +4020,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-cache/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-cache/static/forge-orm-example/package.json
@@ -19,7 +19,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -3323,9 +3323,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -4031,16 +4031,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-checklist/static/forge-orm-example/package.json
@@ -19,7 +19,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
+        "@atlaskit/dynamic-table": "^19.1.2",
         "@forge/bridge": "^6.1.0",
         "mobx": "6.16.1",
         "mobx-react": "9.2.2",
@@ -27,7 +27,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "8.1.4"
+        "vite": "8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@atlaskit/analytics-next": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.2.1.tgz",
-      "integrity": "sha512-6VJL2XtCIQgT39KI7ZiYpOIVS6rmsM7oW2iszkgLofMuwnjoD3d+q8dm01zghMKkNJLRxGPVOw2kNmIZZCbtPw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.3.1.tgz",
+      "integrity": "sha512-9uhQjXYCL1zIxse84iqNxzGDpeveIw5NtEoLDBnLncgo9n8Wj6Nf9KohgtakHVpkQCUhl05yvZA6OnGSRX0Fgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next-stable-react-context": "1.0.1",
@@ -211,21 +211,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -249,6 +249,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {
@@ -587,9 +612,9 @@
       }
     },
     "node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4197,9 +4222,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4441,9 +4466,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5088,16 +5113,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-drizzle-driver-simple/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
+    "@atlaskit/dynamic-table": "^19.1.2",
     "@forge/bridge": "^6.1.0",
     "mobx": "6.16.1",
     "mobx-react": "9.2.2",
@@ -22,7 +22,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "8.1.4"
+    "vite": "8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
+        "@atlaskit/dynamic-table": "^19.1.2",
         "@forge/bridge": "^6.1.0",
         "mobx": "6.16.1",
         "mobx-react": "9.2.2",
@@ -27,7 +27,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@atlaskit/analytics-next": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.2.1.tgz",
-      "integrity": "sha512-6VJL2XtCIQgT39KI7ZiYpOIVS6rmsM7oW2iszkgLofMuwnjoD3d+q8dm01zghMKkNJLRxGPVOw2kNmIZZCbtPw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.3.1.tgz",
+      "integrity": "sha512-9uhQjXYCL1zIxse84iqNxzGDpeveIw5NtEoLDBnLncgo9n8Wj6Nf9KohgtakHVpkQCUhl05yvZA6OnGSRX0Fgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next-stable-react-context": "1.0.1",
@@ -211,21 +211,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -249,6 +249,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {
@@ -587,9 +612,9 @@
       }
     },
     "node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4197,9 +4222,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4441,9 +4466,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5088,16 +5113,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-dynamic/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
+    "@atlaskit/dynamic-table": "^19.1.2",
     "@forge/bridge": "^6.1.0",
     "mobx": "6.16.1",
     "mobx-react": "9.2.2",
@@ -22,7 +22,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package-lock.json
@@ -8,10 +8,10 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^24.3.2",
+        "@atlaskit/button": "^24.3.3",
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
-        "@atlaskit/tabs": "^20.1.0",
+        "@atlaskit/dynamic-table": "^19.1.2",
+        "@atlaskit/tabs": "^20.1.1",
         "@atlaskit/tokens": "^15.8.0",
         "@forge/bridge": "^6.1.0",
         "mobx": "6.16.1",
@@ -30,7 +30,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "24.3.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.2.tgz",
-      "integrity": "sha512-CBJcLDxusbOsht4JDsXC8l236nlYO21keBM5aRqm+968PPMqqP5a2dL9AvY6CJrRgFyAJ3p1nlsKNVISUD59uQ==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.3.tgz",
+      "integrity": "sha512-bp1sh7yXKh/sh32Zaj1C5TcQLT1AD0f1k9bJX29SMRod5e0g5ff96WiQ+hl7UEvFrt3eU1I1t4WYzXB0uqzR/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.3.0",
@@ -157,11 +157,11 @@
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.6.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
@@ -186,6 +186,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/button/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/css": {
@@ -247,21 +272,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -285,6 +310,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {
@@ -591,21 +641,46 @@
       }
     },
     "node_modules/@atlaskit/tabs": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.0.tgz",
-      "integrity": "sha512-5tco3/aP6rXE8F2eIJLtCoVudUkI3juxxD7hv/H/hi6EogkD9iK+GtwA1jDaXLkLODSPvEHzNZz8ZBeA9Np6jw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.1.tgz",
+      "integrity": "sha512-/NWjazkafGfM2dbophjIn5sTEgKX0F8KC0xNcNTPPUSp2upZ7rLg/r1iDvS5ynLIzYhHKH+mWK35T/gf6exWXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/tabs/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/theme": {
@@ -4251,9 +4326,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4495,9 +4570,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5142,16 +5217,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-optimistic-locking/static/forge-orm-example/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "dependencies": {
-    "@atlaskit/button": "^24.3.2",
+    "@atlaskit/button": "^24.3.3",
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
-    "@atlaskit/tabs": "^20.1.0",
+    "@atlaskit/dynamic-table": "^19.1.2",
+    "@atlaskit/tabs": "^20.1.1",
     "@atlaskit/tokens": "^15.8.0",
     "@forge/bridge": "^6.1.0",
     "mobx": "6.16.1",
@@ -25,7 +25,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -3323,9 +3323,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -4031,16 +4031,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-org-tracker/static/forge-orm-example/package.json
@@ -20,7 +20,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
+        "@atlaskit/dynamic-table": "^19.1.2",
         "@forge/bridge": "^6.1.0",
         "forge-sql-orm": "^2.2.3",
         "mobx": "6.16.1",
@@ -28,7 +28,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@atlaskit/analytics-next": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.2.1.tgz",
-      "integrity": "sha512-6VJL2XtCIQgT39KI7ZiYpOIVS6rmsM7oW2iszkgLofMuwnjoD3d+q8dm01zghMKkNJLRxGPVOw2kNmIZZCbtPw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.3.1.tgz",
+      "integrity": "sha512-9uhQjXYCL1zIxse84iqNxzGDpeveIw5NtEoLDBnLncgo9n8Wj6Nf9KohgtakHVpkQCUhl05yvZA6OnGSRX0Fgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next-stable-react-context": "1.0.1",
@@ -212,21 +212,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -250,6 +250,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {
@@ -588,9 +613,9 @@
       }
     },
     "node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4430,9 +4455,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4674,9 +4699,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5321,16 +5346,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-query-analyses/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
+    "@atlaskit/dynamic-table": "^19.1.2",
     "@forge/bridge": "^6.1.0",
     "forge-sql-orm": "^2.2.3",
     "mobx": "6.16.1",
@@ -23,7 +23,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-simple/static/forge-orm-example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/dynamic-table": "^19.1.1",
+        "@atlaskit/dynamic-table": "^19.1.2",
         "@forge/bridge": "^6.1.0",
         "mobx": "6.16.1",
         "mobx-react": "9.2.2",
@@ -26,7 +26,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@atlaskit/analytics-next": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.2.1.tgz",
-      "integrity": "sha512-6VJL2XtCIQgT39KI7ZiYpOIVS6rmsM7oW2iszkgLofMuwnjoD3d+q8dm01zghMKkNJLRxGPVOw2kNmIZZCbtPw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-12.3.1.tgz",
+      "integrity": "sha512-9uhQjXYCL1zIxse84iqNxzGDpeveIw5NtEoLDBnLncgo9n8Wj6Nf9KohgtakHVpkQCUhl05yvZA6OnGSRX0Fgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next-stable-react-context": "1.0.1",
@@ -210,21 +210,21 @@
       }
     },
     "node_modules/@atlaskit/dynamic-table": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.1.tgz",
-      "integrity": "sha512-peZPWwvEr2Y59m7Y9Ch6GxjUJzL5ZcUM+E7KLJXtj7wwo3sXgS8PhD3S+/0Ta66BB6tGAVtDnhqRW3W6MNUMEQ==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/dynamic-table/-/dynamic-table-19.1.2.tgz",
+      "integrity": "sha512-MzGc11AmemZvGIYnDxEuyGGo1mHxPhOr5PTtEBpod6x2N6/vYqbnCJKpDQLTx+f780yN81HmT6d2syQzKoxU0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/pagination": "^17.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^3.1.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
@@ -248,6 +248,31 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/dynamic-table/node_modules/@atlaskit/primitives": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.3.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.8.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/editor-prosemirror": {
@@ -586,9 +611,9 @@
       }
     },
     "node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4186,9 +4211,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4430,9 +4455,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5077,16 +5102,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-simple/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-simple/static/forge-orm-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/dynamic-table": "^19.1.1",
+    "@atlaskit/dynamic-table": "^19.1.2",
     "@forge/bridge": "^6.1.0",
     "mobx": "6.16.1",
     "mobx-react": "9.2.2",
@@ -21,7 +21,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -3323,9 +3323,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -4031,16 +4031,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-sql-executor/static/forge-orm-example/package.json
@@ -19,7 +19,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
+++ b/examples/forge-sql-orm-example-vector/static/forge-orm-example/package-lock.json
@@ -8,11 +8,11 @@
       "name": "forge_sql_orm_example_frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@atlaskit/button": "^24.3.2",
+        "@atlaskit/button": "^24.3.3",
         "@atlaskit/css-reset": "^8.1.0",
-        "@atlaskit/primitives": "^20.6.0",
-        "@atlaskit/section-message": "^9.2.2",
-        "@atlaskit/tabs": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
+        "@atlaskit/section-message": "^9.2.3",
+        "@atlaskit/tabs": "^20.1.1",
         "@atlaskit/textfield": "^9.1.0",
         "@forge/bridge": "^6.1.0",
         "react": "^18.3.1",
@@ -29,7 +29,7 @@
         "prettier": "^3.9.5",
         "prettier-plugin-pkg": "^0.22.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@atlaskit/adf-schema": {
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@atlaskit/button": {
-      "version": "24.3.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.2.tgz",
-      "integrity": "sha512-CBJcLDxusbOsht4JDsXC8l236nlYO21keBM5aRqm+968PPMqqP5a2dL9AvY6CJrRgFyAJ3p1nlsKNVISUD59uQ==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-24.3.3.tgz",
+      "integrity": "sha512-bp1sh7yXKh/sh32Zaj1C5TcQLT1AD0f1k9bJX29SMRod5e0g5ff96WiQ+hl7UEvFrt3eU1I1t4WYzXB0uqzR/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/analytics-next": "^12.3.0",
@@ -174,11 +174,11 @@
         "@atlaskit/icon": "^37.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.6.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
         "@atlaskit/spinner": "^20.1.0",
         "@atlaskit/theme": "^26.1.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/tooltip": "^23.1.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@atlaskit/button/node_modules/@atlaskit/tokens": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.7.0.tgz",
-      "integrity": "sha512-gojVuCheaOhWNDOulE+wo9eJMrxNhcQviBvj02Fo5Z9Rhstm6PwXkQYeAnXHHf2uyugaEbNCukKj3mFBA6VEmg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -347,10 +347,35 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/heading/node_modules/@atlaskit/primitives": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
+      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/app-provider": "^5.1.0",
+        "@atlaskit/css": "^1.0.0",
+        "@atlaskit/ds-lib": "^8.0.0",
+        "@atlaskit/interaction-context": "^4.0.0",
+        "@atlaskit/react-compiler-gating": "^0.2.0",
+        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/visually-hidden": "^4.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@atlaskit/heading/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -427,16 +452,16 @@
       }
     },
     "node_modules/@atlaskit/link": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.1.0.tgz",
-      "integrity": "sha512-YaxFmoyXcuCH3XXto/My4JNPaPngLtu0YfWqL0z8ec5hGMjAwlRnVR37u5hd5TvUvDwgQlAwb+bdSDt2l8V0zw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/link/-/link-4.3.1.tgz",
+      "integrity": "sha512-fbnBI+siZ2THN2GuV5pkvYU1JxeZvbiWuTF/GQRiazOiqui28kAtnw7GrmCPlR3s96GaXbp2w0KLgoReeZZJUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -445,9 +470,9 @@
       }
     },
     "node_modules/@atlaskit/link/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -568,18 +593,18 @@
       }
     },
     "node_modules/@atlaskit/primitives": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-20.6.0.tgz",
-      "integrity": "sha512-pVewMpXm6u9W4fSVQLeOZWGwzBqgbGIaBPReVbIFuDU/ZQQ2vJuPM3hDV+N/Aj7iAYnb0pVQc/5mTTA1bUcdNw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-21.0.0.tgz",
+      "integrity": "sha512-zjikZNVSgNhk0C6k8GCncyq2ZCQXlh+yAxr1pv81BkKnpEjaabfSCqxMsOMnvJLWNpxAfTalQF9USH9alaf7sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.2.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/app-provider": "^5.1.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/ds-lib": "^8.0.0",
         "@atlaskit/interaction-context": "^4.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.6.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@atlaskit/visually-hidden": "^4.1.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0",
@@ -593,9 +618,9 @@
       }
     },
     "node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.6.0.tgz",
-      "integrity": "sha512-U1AJODBzYnLM0G/a7LgVJKf+J59GMimWHAtGnz4qSvBoFqMHcZWhf7t6nSn8JtDVoR7uVvTNwLnnUEp7IxSfOw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -621,20 +646,20 @@
       }
     },
     "node_modules/@atlaskit/section-message": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.2.tgz",
-      "integrity": "sha512-d43n9sNhHAqJPZuq8D5JdhpRnYTOr5CBwHvG4OGTd79+Yi7KYdJeuZhrR5iDtr+XZ65y3hRUM069QgYA5m++VA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/section-message/-/section-message-9.2.3.tgz",
+      "integrity": "sha512-JVu7ZaTcgbcsI1J7sN9mS3Sdqy3CUNDDiNQ31U+1FQ61Efu5UlIPv7IhIrKrb9l/ETS61PtB9TgW+XyV1ogP8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/button": "^24.3.0",
         "@atlaskit/css": "^1.0.0",
         "@atlaskit/heading": "^6.2.0",
         "@atlaskit/icon": "^37.0.0",
-        "@atlaskit/link": "^4.1.0",
+        "@atlaskit/link": "^4.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.5.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.5.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0"
       },
       "peerDependencies": {
@@ -642,9 +667,9 @@
       }
     },
     "node_modules/@atlaskit/section-message/node_modules/@atlaskit/tokens": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.5.0.tgz",
-      "integrity": "sha512-S9qnw5IDg3fEP0rKsorFu4y+SrY2g3GsNn7KPqY82PiMIbkQj7Uca0Abfgl2qozuHFY3AeM1roF185ZxWuNuag==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -729,16 +754,16 @@
       }
     },
     "node_modules/@atlaskit/tabs": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.0.tgz",
-      "integrity": "sha512-5tco3/aP6rXE8F2eIJLtCoVudUkI3juxxD7hv/H/hi6EogkD9iK+GtwA1jDaXLkLODSPvEHzNZz8ZBeA9Np6jw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tabs/-/tabs-20.1.1.tgz",
+      "integrity": "sha512-/NWjazkafGfM2dbophjIn5sTEgKX0F8KC0xNcNTPPUSp2upZ7rLg/r1iDvS5ynLIzYhHKH+mWK35T/gf6exWXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@atlaskit/analytics-next": "^12.1.0",
+        "@atlaskit/analytics-next": "^12.3.0",
         "@atlaskit/platform-feature-flags": "^2.0.0",
-        "@atlaskit/primitives": "^20.1.0",
+        "@atlaskit/primitives": "^21.0.0",
         "@atlaskit/react-compiler-gating": "^0.2.0",
-        "@atlaskit/tokens": "^15.1.0",
+        "@atlaskit/tokens": "^15.8.0",
         "@babel/runtime": "^7.0.0",
         "@compiled/react": "^0.20.0"
       },
@@ -747,9 +772,9 @@
       }
     },
     "node_modules/@atlaskit/tabs/node_modules/@atlaskit/tokens": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.1.0.tgz",
-      "integrity": "sha512-J7TPuY0B1UTxkRyGw/ksu1/AEWEajeOLWSqqLhtZLc9AYgf7f9sMKjFYop6dyR1BHvIbbszNrn6gAJ8l+2BXfw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-15.8.0.tgz",
+      "integrity": "sha512-b4yW+8Td1qEtNfv1hHTHiK9Fgp/FPHPqdaQN9QGiQCSUrMC7er4Z6ST2gXhkiGexUcgKIPGcQRDZc4DQf7aKOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/ds-lib": "^8.0.0",
@@ -4444,9 +4469,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4688,9 +4713,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5326,16 +5351,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/examples/forge-sql-orm-example-vector/static/forge-orm-example/package.json
+++ b/examples/forge-sql-orm-example-vector/static/forge-orm-example/package.json
@@ -4,11 +4,11 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@atlaskit/button": "^24.3.2",
+    "@atlaskit/button": "^24.3.3",
     "@atlaskit/css-reset": "^8.1.0",
-    "@atlaskit/primitives": "^20.6.0",
-    "@atlaskit/section-message": "^9.2.2",
-    "@atlaskit/tabs": "^20.1.0",
+    "@atlaskit/primitives": "^21.0.0",
+    "@atlaskit/section-message": "^9.2.3",
+    "@atlaskit/tabs": "^20.1.1",
     "@atlaskit/textfield": "^9.1.0",
     "@forge/bridge": "^6.1.0",
     "react": "^18.3.1",
@@ -25,7 +25,7 @@
     "prettier": "^3.9.5",
     "prettier-plugin-pkg": "^0.22.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "scripts": {
     "build": "vite build",

--- a/forge-sql-orm-cli/package-lock.json
+++ b/forge-sql-orm-cli/package-lock.json
@@ -32,7 +32,7 @@
         "knip": "^6.27.0",
         "reflect-metadata": "^0.2.2",
         "typescript": "^6.0.3",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vitest": "^4.1.10"
       }
     },
@@ -4682,9 +4682,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -5379,16 +5379,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/forge-sql-orm-cli/package.json
+++ b/forge-sql-orm-cli/package.json
@@ -64,7 +64,7 @@
     "knip": "^6.27.0",
     "reflect-metadata": "^0.2.2",
     "typescript": "^6.0.3",
-    "vite": "^8.1.4",
+    "vite": "^8.1.5",
     "vitest": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.10"
   },

--- a/forge-sql-orm-extra/package-lock.json
+++ b/forge-sql-orm-extra/package-lock.json
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -4683,16 +4683,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5234,9 +5234,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -6402,16 +6402,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {


### PR DESCRIPTION
Automated dependency update produced by `.github/workflows/autoupdate.yml`. Will auto-merge once required checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vite across the SQL ORM examples and CLI tooling to version 8.1.5.
  * Refreshed selected Atlaskit components used by several examples, including buttons, tables, tabs, text areas, and layout primitives.
  * Applied compatible patch updates to improve consistency across example applications without changing their functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->